### PR TITLE
Fix flow errors, introduce invariant() helper function

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+<PROJECT_ROOT>/lib/.*
 
 [include]
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -113,6 +113,12 @@ export const Assert = {
   }
 };
 
+// A function usable to enforce invariants in the code that are
+// recognized by Flow, relies on https://github.com/facebook/flow/issues/2617
+export function invariant(cond: boolean, errMsg: string = "Invariant failed") {
+  if (!cond) throw new Error(errMsg);
+}
+
 export function uint8_to_buf(value: number): Buffer {
   Precondition.checkIsUint8(value, "invalid uint8 value");
 


### PR DESCRIPTION
Motivation: In the implementation of pool owner support 16 flow errors were apparently introduced. I was trying to find a convenient way to do type narrowing with our Asser.assert() utility function but Flow does not seem to support custom type narrowing functions.

What I found though is that Flow has an apparently hard-coded behavior that whatever statement is in a function called "invariant" it results in corresponding type narrowing, so this PR is leveraging that property which is apparently present in flow for over 4 years: https://github.com/facebook/flow/issues/2617 and seems to be recognized by the community, though it is regarded as obscure: https://github.com/facebook/flow/issues/6052

I was also considering whether to completely replace `assert.Assert()` with `invariant()` but most of the instances were
 run time validation checks, like response length where I found it a bit weird to be enforcing an "invariant" as I perceive that as something that is "provably" true based on the logic of the code itself rather than enforcement of some external factor

Changes:
* introduce custom `invariant()` function that does the same as `Assert.assert()` but is meant to do type narrowing in Flow, leveraging the fact that Flow recognizes it as such

Testing:
* `yarn flow` passes with 0 errors. I also tried putting the negations of the conditions I checked with `invariant` and they actually made `yarn flow` fail with corresponding errors, confirming that flow is not completely silenced by casting the checked values to `any` or something similar
