### PR TITLE
Fix validation of numerical parameters passed as strings

### DIFF
--- a/test/src/integration/__fixtures__/signTx.js
+++ b/test/src/integration/__fixtures__/signTx.js
@@ -129,7 +129,24 @@ export const outputs = {
         ]
       }
     ]
-  }
+  },
+  multiassetBigNumber: {
+    addressHex: utils.buf_to_hex(utils.bech32_decodeAddress(
+      "addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r"
+    )),
+    amountStr: "24103998870869519",
+    tokenBundle: [
+      {
+        policyIdHex: "95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+        tokens: [
+          {
+            assetNameHex: "74652474436f696e",
+            amountStr: "24103998870869519"
+          }
+        ]
+      }
+    ]
+  },
 };
 
 export const certificates = {
@@ -159,6 +176,7 @@ export const sampleMetadataHashHex = "deadbeef".repeat(8);
 export const sampleFeeStr = "42";
 export const sampleTtlStr = "10";
 export const sampleValidityIntervalStartStr = "47";
+export const sampleBigIntStr = "24103998870869519";
 
 
 export const resultsByron = {
@@ -459,6 +477,20 @@ export const resultsMary = {
         path: str_to_path("1852'/1815'/0'/0/0"),
         witnessSignatureHex:
           "391c3f0ba1c31b11d6cd36ffb5dcfa1c88a54daae043a1f48402d50d9f67388cca50536b44ab0b9b79fcd922da26e847e0e186d844e8d90543d0c56c2afffa0c"
+      }
+    ]
+  },
+
+  bigNumbersEverywhere: {
+    /*
+    * txbody: a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff821b0055a275925d560fa1581c95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39a14874652474436f696e1b0055a275925d560f021b0055a275925d560f031b0055a275925d560f081b0055a275925d560f
+    */
+    txHashHex: "e60735a3cc71a8a3f89652797c3e650d6ed80059c0b59978c59858dcf6f8ca48",
+    witnesses: [
+      {
+        path: str_to_path("1852'/1815'/0'/0/0"),
+        witnessSignatureHex:
+          "632cd935550a71c1e1869e6f5749ee4cb8c268cbe014138561fc2d1045b5b2be84526cfd5a6fea01de99bdf903fa17c79a58a832b5cdcb1c999bcbe995a56806"
       }
     ]
   },

--- a/test/src/integration/signTx.js
+++ b/test/src/integration/signTx.js
@@ -6,6 +6,7 @@ import {
   outputs,
   sampleFeeStr,
   sampleTtlStr,
+  sampleBigIntStr,
   certificates,
   withdrawals,
   sampleMetadataHashHex,
@@ -446,5 +447,23 @@ describe("signTxOrdinaryMary", async () => {
       sampleValidityIntervalStartStr
     );
     expect(response).to.deep.equal(resultsMary.multiassetManyTokens);
+  });
+
+  it("Mary era transaction with big numbers", async () => {
+    const response = await ada.signTransaction(
+      NetworkIds.MAINNET,
+      ProtocolMagics.MAINNET,
+      [inputs.utxoShelley],
+      [
+        outputs.multiassetBigNumber,
+      ],
+      sampleBigIntStr,
+      sampleBigIntStr,
+      [],
+      [],
+      null,
+      sampleBigIntStr
+    );
+    expect(response).to.deep.equal(resultsMary.bigNumbersEverywhere);
   });
 });


### PR DESCRIPTION
Motivation: big numbers validation in various places was incorrect because it was casting the value to native js numbers which do not work well over a certain threshold lower than 2^64, The used safe_parseInt function thrown (as it was designed to) for numbers over max safe integer in javascript, so numbers over that threshold (~2^53) were basically causing ledgerjs validation to fail and the transaction was not passed to Ledger.

I was originally planning to just extend the original simplistic validation of integer strings but it got awkward when I wanted to generalize it for uint64 and ADA amount (adding a min-max range to the function interface) and there is also validation comparing pool margin numerator and denominator.

So it felt kind of shortsighted to create a relatively ugly helper function that would require further "hacking" as more numbers with different constraints would be introduced. Therefore I went with JSBI library implementing ES2020 BigInt. I considered using BigInt directly but it seems to be too "bleeding edge" and it may not work in older, but still relatively new browsers and developers may face unnecessary issues with that. Moreover, it seems tricky to be translated by Babel: https://javascript.info/bigint#polyfills and the plugin that I found for it https://www.npmjs.com/package/babel-plugin-transform-bigint doesn't seem very stable and well adopted and I didn't manage to get it working, it was failing with `Error: Cannot find module './jsbi.mjs'`

Changes:
* refactor validation of numbers to use BigInt (JSBI)
* add testcase containing a transaction with big numbers

Testing:
* `yarn test-integration` passes

