### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+ 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [2.2.0](https://github.com/cardano-foundation/ledgerjs-hw-app-cardano/compare/v2.1.0...v2.2.0) - [February 8th 2020]
+
+Works with Ledger Cardano app 2.2.0 and is backwards compatible with older versions down to 2.0.4/2.0.5\*. Older versions of this js library do not support Ledger Cardano app 2.2.0, hence an update to this version of the library is required before Ledger Cardano app 2.2.0 is released.
+
+### Added
+
+- Support for Allegra-era transaction min validity property, transaction TTL is now optional: https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/27/files
+- Support for Mary-era multiasset outputs (no minting yet) https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/27/files
+- Update docs with a stake pool registration (as an owner) example https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/23
+
+ 
+### Changed
+
+### Fixed
+
+- Fixed incorrect validation of numerical parameters passed as strings which failed for values over JS max safe integer: https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/29
+
+## [2.1.0](https://github.com/cardano-foundation/ledgerjs-hw-app-cardano/releases/tag/v2.1.0) - [December 11th 2020]
+
+Works with Ledger Cardano app 2.1.0 and is backwards compatible with 2.0.4/2.0.5 as well\*. Older versions of this library do not support Ledger Cardano app 2.1.0, therefore an update to this version of the library is required before Ledger Cardano app 2.1.0 is released.
+
+### Added
+
+- Support for bulk public key export https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/13/files
+- Support for stake pool registration certificate as a pool owner https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/12
+- Docs for available calls https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/17
+ 
+### Changed
+
+- Allow transactions without outputs: https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/16
+- Updated flow types for Certificates, [commit](https://github.com/vacuumlabs/ledgerjs-cardano-shelley/commit/c50d383fe65e0db1787bda39984423f165bf0316#diff-6e0ee7e0e42296aeb681e34e50808e744aeeeff03702bab5ab7994bb4e0562e3)
+
+### Fixed
+
+## [2.0.1] - [August 20th 2020]
+ 
+### Added
+
+- Certificate and address type Flow enums, [commit](https://github.com/vacuumlabs/ledgerjs-cardano-shelley/commit/df08b3fdb7383b1065e7ad971626430a126f98aa)
+ 
+### Changed
+
+### Fixed
+
+
+## [2.0.0] - [August 18th 2020]
+
+First release with Shelley-era support, works with Ledger Cardano app version 2.0.4 (Nano S) and 2.0.5 (Nano X). Older versions of this library no longer work with the Cardano blockchain.
+
+
+### Added
+
+### Changed
+
+### Fixed
+
+
+\* *backwards compatibility refers only to features supported by the respective app versions, unsupported features result in an error being thrown.*

--- a/README.md
+++ b/README.md
@@ -16,4 +16,11 @@ Run example by `node example-node/lib/index.js`.
 Automated tests are provided. There are two types of tests
 
 1. `yarn test-integration`. Tests JS api.
-2. `yarn test-direct`. Mostly tests vartious corner cases. There are some extensive tests which are disabled by default, see tests source code. Also note that for these tests it is advised to install developer version of Cardano app with _headless_ mode enabled, otherwise you spend your entire life confirming various prompts on device.
+2. `yarn test-direct`. Mostly tests for different corner cases. There are some extensive tests which are disabled by default, see tests source code.
+
+Note that for these tests it is advisable to install the developer build of the Cardano app with _headless_ mode enabled unless you want to verify the UI flows, otherwise you will need a significant amount of time to manually confirm all prompts on the device.
+
+### Documentation
+
+* available calls documented in [docs folder](/docs)
+* [CHANGELOG](CHANGELOG.md)


### PR DESCRIPTION
Motivation: There is currently no formal documentation capturing changes between different versions of this library, therefore external developers lack the context of when switching to a new version is actually needed and what are the relevant changes.

Changes:
* add a changelog file capturing most relevant changes so far (since version 2.0.0 as there is no point in keeping track of older versions that do not work anymore as they were meant for Byron era)