### PR TITLE
Rename metadata to auxiliary data

### DIFF
--- a/src/errors/invalidDataReason.ts
+++ b/src/errors/invalidDataReason.ts
@@ -96,8 +96,8 @@ export enum InvalidDataReason {
   WITHDRAWAL_INVALID_AMOUNT = "invalid withdrawal amount",
   WITHDRAWAL_INVALID_PATH = "invalid withdrawal path",
 
-  METADATA_UNKNOWN_TYPE = "unknown metadata type",
-  METADATA_INVALID_HASH = "invalid metadata hash",
+  AUXILIARY_DATA_UNKNOWN_TYPE = "unknown auxiliary data type",
+  AUXILIARY_DATA_INVALID_HASH = "invalid auxiliary data hash",
 
   VALIDITY_INTERVAL_START_INVALID = "invalid validity interval start",
 

--- a/src/interactions/serialization/txInit.ts
+++ b/src/interactions/serialization/txInit.ts
@@ -35,7 +35,7 @@ export function serializeTxInit(tx: ParsedTransaction, signingMode: TransactionS
         uint8_to_buf(tx.network.networkId),
         uint32_to_buf(tx.network.protocolMagic),
         _serializeOptionFlag(tx.ttl != null),
-        _serializeOptionFlag(tx.metadata != null),
+        _serializeOptionFlag(tx.auxiliaryData != null),
         _serializeOptionFlag(tx.validityIntervalStart != null),
         _serializeSigningMode(signingMode),
         uint32_to_buf(tx.inputs.length as Uint32_t),

--- a/src/interactions/serialization/txOther.ts
+++ b/src/interactions/serialization/txOther.ts
@@ -35,11 +35,11 @@ export function serializeTxTtl(
     ]);
 }
 
-export function serializeTxMetadata(
-    metadataHashHex: HexString
+export function serializeTxAuxiliaryData(
+    auxiliaryDataHashHex: HexString
 ) {
     return Buffer.concat([
-        hex_to_buf(metadataHashHex)
+        hex_to_buf(auxiliaryDataHashHex)
     ])
 }
 

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,4 +1,4 @@
-import { AddressType, CertificateType, PoolOwnerType, RelayType, TransactionMetadataType, TransactionSigningMode, TxOutputDestinationType } from './public'
+import { AddressType, CertificateType, PoolOwnerType, RelayType, TransactionSigningMode, TxAuxiliaryDataType, TxOutputDestinationType } from './public'
 
 // Basic primitives
 export type VarlenAsciiString = string & { __type: 'ascii' }
@@ -15,7 +15,7 @@ export type Uint16_t = number & { __type: 'uint16_t' }
 export type Uint8_t = number & { __type: 'uint8_t' }
 
 // Reexport blockchain spec
-export { AddressType, CertificateType, RelayType, PoolOwnerType, TransactionMetadataType, TransactionSigningMode, TxOutputDestinationType }
+export { AddressType, CertificateType, RelayType, PoolOwnerType, TxAuxiliaryDataType, TransactionSigningMode, TxOutputDestinationType }
 export { Version, DeviceCompatibility } from './public'
 // Our types
 export const KEY_HASH_LENGTH = 28;
@@ -55,9 +55,9 @@ export type ParsedNetwork = {
     networkId: Uint8_t
 }
 
-export type ParsedMetadata = {
-    type: TransactionMetadataType.ARBITRARY_HASH
-    metadataHashHex: FixlenHexString<32>
+export type  ParsedTxAuxiliaryData = {
+    type: TxAuxiliaryDataType.ARBITRARY_HASH
+    hashHex: FixlenHexString<32>
 }
 
 export type ParsedTransaction = {
@@ -68,7 +68,7 @@ export type ParsedTransaction = {
     ttl: Uint64_str | null
     certificates: ParsedCertificate[]
     withdrawals: ParsedWithdrawal[]
-    metadata: ParsedMetadata | null
+    auxiliaryData:  ParsedTxAuxiliaryData | null
     validityIntervalStart: Uint64_str | null
 }
 

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -691,36 +691,36 @@ export type SignedTransactionData = {
 };
 
 /**
- * Kind of transaction metatada supplied to Ledger
+ * Kind of transaction auxiliary data supplied to Ledger
  * @category Basic types
- * @see [[TransactionMetadata]]
+ * @see [[TxAuxiliaryData]]
  */
-export enum TransactionMetadataType {
-    /** Metadata is supplied as raw hash value */
+export enum TxAuxiliaryDataType {
+    /** Auxiliary data is supplied as raw hash value */
     ARBITRARY_HASH = 'arbitrary_hash',
 
     // CatalystVoting = 'catalyst_voting'
 }
 
 /**
- * Specifies transaction metadata.
- * Metadata can be supplied to Ledger in multiple forms.
+ * Specifies transaction auxiliary data.
+ * Auxiliary data can be supplied to Ledger possibly in multiple forms.
  * @category Basic types
- * @see [[TransactionMetadataType]]
+ * @see [[TxAuxiliaryDataType]]
  */
-export type TransactionMetadata =
+export type TxAuxiliaryData =
     {
-        type: TransactionMetadataType.ARBITRARY_HASH
-        params: MetadataArbitraryHashParams
+        type: TxAuxiliaryDataType.ARBITRARY_HASH
+        params: TxAuxiliaryDataArbitraryHashParams
     }
 
 /**
- * Metadata is supplied as raw hash. Ledger will just display this hash to the user
- * @see [[TransactionMetadata]]
+ * Auxiliary data is supplied as raw hash. Ledger will just display this hash to the user
+ * @see [[TxAuxiliaryData]]
  */
-export type MetadataArbitraryHashParams = {
+export type TxAuxiliaryDataArbitraryHashParams = {
     /** Hash of the transaction metadata */
-    metadataHashHex: string
+    hashHex: string
 }
 
 /**
@@ -762,9 +762,9 @@ export type Transaction = {
      */
     withdrawals?: Array<Withdrawal> | null,
     /**
-     * Transaction metadata (if any)
+     * Transaction auxiliary data (if any)
      */
-    metadata?: TransactionMetadata | null,
+    auxiliaryData?: TxAuxiliaryData | null,
     /**
      * Validity start (block height) if any.
      * Transaction becomes valid only starting from this block height.

--- a/test/integration/__fixtures__/signTx.ts
+++ b/test/integration/__fixtures__/signTx.ts
@@ -1,5 +1,5 @@
 import type { SignedTransactionData, Transaction, TxInput, TxOutput, TxOutputDestination } from "../../../src/Ada";
-import { AddressType, CertificateType, Networks, TransactionMetadataType, TxOutputDestinationType, utils } from "../../../src/Ada";
+import { AddressType, CertificateType, Networks, TxAuxiliaryDataType, TxOutputDestinationType, utils } from "../../../src/Ada";
 import { str_to_path } from "../../../src/utils/address";
 
 export const inputs: Record<
@@ -678,13 +678,13 @@ export const testsShelleyOther: TestcaseShelley[] = [
     },
   },
   {
-    testname: "Should correctly sign tx with nonempty metadata",
+    testname: "Should correctly sign tx with nonempty auxiliary data",
     tx: {
       ...shelleyBase,
-      metadata: {
-        type: TransactionMetadataType.ARBITRARY_HASH,
+      auxiliaryData: {
+        type: TxAuxiliaryDataType.ARBITRARY_HASH,
         params: {
-          metadataHashHex: "deadbeef".repeat(8)
+          hashHex: "deadbeef".repeat(8)
         }
       }
     },
@@ -710,10 +710,10 @@ export const testsShelleyOther: TestcaseShelley[] = [
       ...shelleyBase,
       inputs: [inputs.utxoNonReasonable],
       outputs: [outputs.internalBaseWithStakingPathNonReasonable],
-      metadata: {
-        type: TransactionMetadataType.ARBITRARY_HASH,
+      auxiliaryData: {
+        type: TxAuxiliaryDataType.ARBITRARY_HASH,
         params: {
-          metadataHashHex: "deadbeef".repeat(8)
+          hashHex: "deadbeef".repeat(8)
         },
       }
     },


### PR DESCRIPTION
Motivation: reflect latest changes in Cardano's CDDL: https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl

Notes:
* renamed metadataHashHex to just hashHex as the purpose is fairly obvious from the encapsulating object type and to make it consistent with the way we pass the metadata hash in the pool registration params object
* I decided to keep the internal "STAGE_METADATA" enum intact as that's still how it's named in  the currently launched ledger app, I'd change it together with Catalyst support

Testing: ran `yarn test-integration` and it passed