### PR TITLE
Enforce consistent indentation of two spaces and no semicolons

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
   "plugins": ["@typescript-eslint", "import", "simple-import-sort", "prettier"],
   "rules": {
     "indent": 2,
+    "semi": ["error", "never"],
     "simple-import-sort/imports": "warn",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,8 @@
     "semi": ["error", "never"],
     "simple-import-sort/imports": "warn",
     "no-unused-vars": "off",
+    "comma-dangle": "off",
+    "@typescript-eslint/comma-dangle": ["error", "always-multiline"],
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
   "extends": ["eslint:recommended", "plugin:import/errors"],
   "plugins": ["@typescript-eslint", "import", "simple-import-sort", "prettier"],
   "rules": {
+    "indent": 2,
     "simple-import-sort/imports": "warn",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [


### PR DESCRIPTION
Motivation: Currently we have files with 4 spaces per tab and 2 spaces per tab indentation which is messy. Turns out we weren't enforcing consistent indentation rule at all which is apparent from an inspection of the enabled rules I did on an arbitrary file

```yarn eslint --print-config src/parsing/poolRegistration.ts```

so the indentation was being kept consistent only within the individual files, likely by the editor itself.

source: https://stackoverflow.com/questions/63775411/is-there-a-way-to-list-all-active-eslint-prettier-rules-in-an-angular-project

Solution:
* explicitly enforce consistent indentation of 2 spaces in .eslintrc, of course this triggers a bunch of errors (like 2000) and would generate a sizeable diff resulting in many conflicts, so I'm leaving this there until we have no active workstream which could otherwise get broken by this, and then we should run `yarn lint --fix`, commit it and merge this

Note:
* not sure why dangling comma enforcement doesn't seem to apply to type exports, but the rest is enforced which is still sharply better than the current state

Testing: `yarn lint` triggers now errors related to inconsitent indentation, see CI checks status

closes #93 and #94