### PR TITLE
rebase PR #24 on top of typescript refactoring

### DIFF
--- a/src/Ada.ts
+++ b/src/Ada.ts
@@ -25,15 +25,18 @@ import { getSerial } from "./interactions/getSerial";
 import { getCompatibility, getVersion } from "./interactions/getVersion";
 import { runTests } from "./interactions/runTests";
 import { showAddress } from "./interactions/showAddress";
+import { signOperationalCertificate } from "./interactions/signOperationalCertificate";
 import { signTransaction } from "./interactions/signTx";
 import { parseAddress } from './parsing/address'
+import { parseOperationalCertificate } from "./parsing/operationalCertificate";
 import { parseSignTransactionRequest } from "./parsing/transaction";
 import type {
   ParsedAddressParams,
+  ParsedOperationalCertificate,
   ParsedSigningRequest,
   ValidBIP32Path,
 } from './types/internal';
-import type { BIP32Path, DerivedAddress, DeviceCompatibility, DeviceOwnedAddress, ExtendedPublicKey, Network, Serial, SignedTransactionData, SignTransactionRequest, Transaction, Version } from './types/public';
+import type { BIP32Path, DerivedAddress, DeviceCompatibility, DeviceOwnedAddress, ExtendedPublicKey, Network, OperationalCertificate, OperationalCertificateSignature, Serial, SignedTransactionData, SignTransactionRequest, Transaction, Version } from './types/public';
 import { AddressType, CertificateType, RelayType, TransactionSigningMode } from "./types/public"
 import utils from "./utils";
 import { assert } from './utils/assert'
@@ -300,6 +303,21 @@ export class Ada {
     const version = yield* getVersion()
     return yield* signTransaction(version, request)
   }
+
+
+
+  async signOperationalCertificate(
+    request: SignOperationalCertificateRequest
+  ): Promise<SignOperationalCertificateResponse> {
+    const parsedOperationalCertificate = parseOperationalCertificate(request)
+
+    return interact(this._signOperationalCertificate(parsedOperationalCertificate), this._send)
+  }
+
+  * _signOperationalCertificate(request: ParsedOperationalCertificate): Interaction<OperationalCertificateSignature> {
+    const version = yield* getVersion()
+    return yield* signOperationalCertificate(version, request)
+  }
 }
 
 /**
@@ -378,6 +396,19 @@ export type GetSerialResponse = Serial
  * @see [[SignTransactionRequest]]
  */
 export type SignTransactionResponse = SignedTransactionData
+
+/**
+ * Sign operational certificate ([[Ada.signOperationalCertificate]]) request data
+ * @category Main
+ * @see [[SignOperationalCertificateResponse]]
+ */
+export type SignOperationalCertificateRequest = OperationalCertificate
+/**
+ * Sign operational certificate ([[Ada.signOperationalCertificate]]) response data
+ * @category Main
+ * @see [[SignOperationalCertificateRequest]]
+ */
+export type SignOperationalCertificateResponse = OperationalCertificateSignature
 
 // reexport
 export type { Transaction, DeviceOwnedAddress }

--- a/src/errors/invalidDataReason.ts
+++ b/src/errors/invalidDataReason.ts
@@ -49,8 +49,6 @@ export enum InvalidDataReason {
   "superfluous pool key hash in a certificate",
   CERTIFICATE_INVALID_TYPE = "invalid certificate type",
 
-  POOL_REGISTRATION_INVALID_POOL_KEY_HASH =
-  "invalid pool key hash in a pool registration certificate",
   POOL_REGISTRATION_INVALID_VRF_KEY_HASH =
   "invalid vrf key hash in a pool registration certificate",
   POOL_REGISTRATION_INVALID_PLEDGE =
@@ -61,10 +59,15 @@ export enum InvalidDataReason {
   "invalid margin in a pool registration certificate",
   POOL_MARGIN_INVALID_MARGIN_DENOMINATOR =
   "pool margin denominator must be a value between 1 and 10^15",
-  POOL_REGISTRATION_INVALID_REWARD_ACCOUNT =
-  "invalid reward account in a pool registration certificate",
   POOL_REGISTRATION_OWNERS_TOO_MANY =
   "too many owners in a pool registration certificate",
+
+  POOL_KEY_INVALID_TYPE =
+  "invalid pool key type",
+  POOL_KEY_INVALID_PATH =
+  "invalid pool key path in a pool registration certificate",
+  POOL_KEY_INVALID_KEY_HASH =
+  "invalid pool key hash in a pool registration certificate",
 
   POOL_OWNER_INVALID_TYPE =
   "invalid owner type",
@@ -74,6 +77,16 @@ export enum InvalidDataReason {
   "invalid owner key hash in a pool registration certificate",
   POOL_REGISTRATION_RELAYS_TOO_MANY =
   "too many pool relays in a pool registration certificate",
+
+  POOL_REWARD_ACCOUNT_INVALID_TYPE =
+  "invalid pool reward account type",
+  POOL_REWARD_ACCOUNT_INVALID_PATH =
+  "invalid pool reward account key path in a pool registration certificate",
+  POOL_REWARD_ACCOUNT_INVALID_HEX =
+  "invalid pool reward account key hash in a pool registration certificate",
+
+  POOL_RETIREMENT_INVALID_RETIREMENT_EPOCH =
+  "invalid pool retirement epoch",
 
   RELAY_INVALID_TYPE =
   "invalid type of a relay in a pool registration certificate",
@@ -121,4 +134,22 @@ export enum InvalidDataReason {
   "single device-owned pool owner is expected in TransactionSigningMode.POOL_REGISTRATION_AS_OWNER",
   SIGN_MODE_POOL_OWNER__WITHDRAWALS_NOT_ALLOWED =
   "no withdrawals allowed in TransactionSigningMode.POOL_REGISTRATION_AS_OWNER",
+
+  SIGN_MODE_POOL_OPERATOR__SINGLE_POOL_REG_CERTIFICATE_REQUIRED =
+  "single pool registration certificate is expected in TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR",
+  SIGN_MODE_POOL_OPERATOR__DEVICE_OWNED_POOL_KEY_REQUIRED =
+  "device owned pool key is required in TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR",
+  SIGN_MODE_POOL_OPERATOR__DEVICE_OWNED_POOL_OWNER_NOT_ALLOWED =
+  "no device-owned pool owner is expected in TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR",
+  SIGN_MODE_POOL_OPERATOR__WITHDRAWALS_NOT_ALLOWED =
+  "no withdrawals allowed in TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR",
+
+  OPERATIONAL_CERTIFICATE_INVALID_KES_KEY =
+  "invalid operational certificate kes key",
+  OPERATIONAL_CERTIFICATE_INVALID_KES_PERIOD =
+  "invalid operational certificate kes period",
+  OPERATIONAL_CERTIFICATE_INVALID_ISSUE_COUNTER =
+  "invalid operational certificate issue counter",
+  OPERATIONAL_CERTIFICATE_INVALID_COLD_KEY_PATH =
+  "invalid operational certificate cold key path",
 }

--- a/src/interactions/common/ins.ts
+++ b/src/interactions/common/ins.ts
@@ -6,6 +6,7 @@ export const enum INS {
   DERIVE_ADDRESS = 0x11,
 
   SIGN_TX = 0x21,
+  SIGN_OPERATIONAL_CERTIFICATE = 0x22,
 
   RUN_TESTS = 0xf0,
 }

--- a/src/interactions/getVersion.ts
+++ b/src/interactions/getVersion.ts
@@ -39,6 +39,7 @@ export function getCompatibility(version: Version): DeviceCompatibility {
   // We restrict forward compatibility only to backward-compatible semver changes
   const v2_2 = isLedgerAppVersionAtLeast(version, 2, 2) && isLedgerAppVersionAtMost(version, 2, Infinity)
   const v2_3 = isLedgerAppVersionAtLeast(version, 2, 3) && isLedgerAppVersionAtMost(version, 2, Infinity)
+  const v2_4 = isLedgerAppVersionAtLeast(version, 2, 4) && isLedgerAppVersionAtMost(version, 2, Infinity)
 
   return {
     isCompatible: v2_2,
@@ -46,6 +47,8 @@ export function getCompatibility(version: Version): DeviceCompatibility {
     supportsMary: v2_2,
     supportsCatalystRegistration: v2_3,
     supportsZeroTtl: v2_3,
+    supportsOperationalCertificate: v2_4,
+    supportsPoolRetirement: v2_4,
   }
 }
 

--- a/src/interactions/serialization/operationalCertificate.ts
+++ b/src/interactions/serialization/operationalCertificate.ts
@@ -1,0 +1,13 @@
+import type { ParsedOperationalCertificate } from "../../types/internal";
+import { hex_to_buf, path_to_buf, uint64_to_buf, } from "../../utils/serialize";
+
+export function serializeOperationalCertificate(
+    { kesPublicKeyHex, kesPeriod, issueCounter, coldKeyPath }: ParsedOperationalCertificate
+): Buffer {
+    return Buffer.concat([
+        hex_to_buf(kesPublicKeyHex),
+        uint64_to_buf(kesPeriod),
+        uint64_to_buf(issueCounter),
+        path_to_buf(coldKeyPath)
+    ]);
+}

--- a/src/interactions/serialization/txCertificate.ts
+++ b/src/interactions/serialization/txCertificate.ts
@@ -1,7 +1,7 @@
 import type { ParsedCertificate, Uint8_t } from "../../types/internal";
 import { CertificateType } from "../../types/internal";
 import { unreachable } from "../../utils/assert";
-import { hex_to_buf, path_to_buf, uint8_to_buf } from "../../utils/serialize";
+import { hex_to_buf, path_to_buf, uint8_to_buf, uint64_to_buf } from "../../utils/serialize";
 
 export function serializeTxCertificate(
     certificate: ParsedCertificate,
@@ -25,6 +25,13 @@ export function serializeTxCertificate(
         case CertificateType.STAKE_POOL_REGISTRATION: {
             return Buffer.concat([
                 uint8_to_buf(certificate.type as Uint8_t),
+            ])
+        }
+        case CertificateType.STAKE_POOL_RETIREMENT: {
+            return Buffer.concat([
+                uint8_to_buf(certificate.type as Uint8_t),
+                path_to_buf(certificate.path),
+                uint64_to_buf(certificate.retirementEpoch),
             ])
         }
         default:

--- a/src/interactions/serialization/txInit.ts
+++ b/src/interactions/serialization/txInit.ts
@@ -9,7 +9,7 @@ const _serializeSigningMode = (
     const value = {
         [TransactionSigningMode.ORDINARY_TRANSACTION]: 3 as Uint8_t,
         [TransactionSigningMode.POOL_REGISTRATION_AS_OWNER]: 4 as Uint8_t,
-        [TransactionSigningMode.__RESEVED_POOL_REGISTRATION_AS_OPERATOR]: 5 as Uint8_t,
+        [TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR]: 5 as Uint8_t,
     }[mode];
 
     assert(value !== undefined, 'Invalid signing mode')

--- a/src/interactions/signOperationalCertificate.ts
+++ b/src/interactions/signOperationalCertificate.ts
@@ -1,0 +1,38 @@
+import { DeviceVersionUnsupported } from "../errors";
+import type { ParsedOperationalCertificate, Version } from "../types/internal";
+import { ED25519_SIGNATURE_LENGTH } from "../types/internal";
+import type { OperationalCertificateSignature, } from '../types/public'
+import { INS } from "./common/ins";
+import type { Interaction, SendParams } from "./common/types";
+import { getCompatibility } from "./getVersion";
+import { serializeOperationalCertificate } from "./serialization/operationalCertificate";
+
+const send = (params: {
+  p1: number,
+  p2: number,
+  data: Buffer,
+  expectedResponseLength?: number
+}): SendParams => ({ ins: INS.SIGN_OPERATIONAL_CERTIFICATE, ...params })
+
+export function* signOperationalCertificate(
+  version: Version,
+  operationalCertificate: ParsedOperationalCertificate,
+): Interaction<OperationalCertificateSignature> {
+  if (!getCompatibility(version).supportsOperationalCertificate) {
+    throw new DeviceVersionUnsupported(`Operational certificate signing not supported by Ledger app version ${version}.`);
+  }
+
+  const P1_UNUSED = 0x00;
+  const P2_UNUSED = 0x00;
+
+  const response = yield send({
+    p1: P1_UNUSED,
+    p2: P2_UNUSED,
+    data: serializeOperationalCertificate(operationalCertificate),
+    expectedResponseLength: ED25519_SIGNATURE_LENGTH,
+  });
+
+  return {
+    signatureHex: response.toString("hex")
+  };
+}

--- a/src/interactions/signTx.ts
+++ b/src/interactions/signTx.ts
@@ -1,16 +1,15 @@
-import { DeviceVersionUnsupported } from '../errors';
-import type {  ParsedCertificate, ParsedInput, ParsedOutput, ParsedSigningRequest, ParsedTransaction, ParsedTxAuxiliaryData, ParsedWithdrawal, Uint64_str, ValidBIP32Path, Version } from "../types/internal";
+import { DeviceVersionUnsupported } from "../errors";
+import type { ParsedCertificate, ParsedInput, ParsedOutput, ParsedSigningRequest, ParsedTransaction, ParsedTxAuxiliaryData, ParsedWithdrawal, Uint64_str, ValidBIP32Path, Version } from "../types/internal";
 import { CertificateType, PoolOwnerType, TX_HASH_LENGTH } from "../types/internal";
-import type { SignedTransactionData, TxAuxiliaryDataSupplement} from '../types/public';
-import { TxAuxiliaryDataSupplementType} from '../types/public';
-import { TransactionSigningMode, TxAuxiliaryDataType } from '../types/public';
+import type { SignedTransactionData, TxAuxiliaryDataSupplement } from "../types/public";
+import { PoolKeyType, TransactionSigningMode, TxAuxiliaryDataSupplementType, TxAuxiliaryDataType } from "../types/public";
 import { assert } from "../utils/assert";
 import { buf_to_hex, hex_to_buf } from "../utils/serialize";
 import { INS } from "./common/ins";
 import type { Interaction, SendParams } from "./common/types";
 import { ensureLedgerAppVersionCompatible, getCompatibility } from "./getVersion";
-import { serializeCatalystRegistrationNonce, serializeCatalystRegistrationRewardsDestination, serializeCatalystRegistrationStakingPath,serializeCatalystRegistrationVotingKey } from "./serialization/catalystRegistration"
-import { serializePoolInitialParams, serializePoolMetadata, serializePoolOwner, serializePoolRelay } from "./serialization/poolRegistrationCertificate";
+import { serializeCatalystRegistrationNonce, serializeCatalystRegistrationRewardsDestination, serializeCatalystRegistrationStakingPath, serializeCatalystRegistrationVotingKey } from "./serialization/catalystRegistration"
+import { serializeFinancials, serializePoolInitialParams, serializePoolInitialParamsLegacy, serializePoolKey, serializePoolMetadata, serializePoolOwner, serializePoolRelay, serializePoolRewardAccount } from "./serialization/poolRegistrationCertificate";
 import { serializeTxAuxiliaryData } from "./serialization/txAuxiliaryData";
 import { serializeTxCertificate } from "./serialization/txCertificate";
 import { serializeTxInit } from "./serialization/txInit";
@@ -119,6 +118,7 @@ function* signTx_addOutput(
 }
 
 function* signTx_addCertificate(
+  version: Version,
   certificate: ParsedCertificate,
 ): Interaction<void> {
   const enum P2 {
@@ -133,54 +133,152 @@ function* signTx_addCertificate(
 
   // additional data for pool certificate
   if (certificate.type === CertificateType.STAKE_POOL_REGISTRATION) {
-    const enum P2 {
-      POOL_PARAMS = 0x30,
-      OWNERS = 0x31,
-      RELAYS = 0x32,
-      METADATA = 0x33,
-      CONFIRMATION = 0x34,
+    if (getCompatibility(version).supportsOperationalCertificate) {
+      yield* signTx_addStakePoolRegistrationCertificate(certificate)
+    } else {
+      yield* signTx_addStakePoolRegistrationCertificateLegacy(certificate)
     }
+  }
+}
 
-    const pool = certificate.pool
+function* signTx_addStakePoolRegistrationCertificate(
+  certificate: ParsedCertificate
+): Interaction<void> {
+  assert(certificate.type === CertificateType.STAKE_POOL_REGISTRATION, "invalid certificate type")
+
+  const enum P2 {
+    INIT = 0x30,
+    POOL_KEY = 0x31,
+    VRF_KEY = 0x32,
+    FINANCIALS = 0x33,
+    REWARD_ACCOUNT = 0x34,
+    OWNERS = 0x35,
+    RELAYS = 0x36,
+    METADATA = 0x37,
+    CONFIRMATION = 0x38,
+  }
+
+  const pool = certificate.pool
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.INIT,
+    data: serializePoolInitialParams(pool),
+    expectedResponseLength: 0,
+  });
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.POOL_KEY,
+    data: serializePoolKey(pool.poolKey),
+    expectedResponseLength: 0,
+  });
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.VRF_KEY,
+    data: hex_to_buf(pool.vrfHashHex),
+    expectedResponseLength: 0,
+  });
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.FINANCIALS,
+    data: serializeFinancials(pool),
+    expectedResponseLength: 0,
+  });
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.REWARD_ACCOUNT,
+    data: serializePoolRewardAccount(pool.rewardAccount),
+    expectedResponseLength: 0,
+  });
+
+  for (const owner of pool.owners) {
     yield send({
       p1: P1.STAGE_CERTIFICATES,
-      p2: P2.POOL_PARAMS,
-      data: serializePoolInitialParams(pool),
-      expectedResponseLength: 0,
-    });
-
-    for (const owner of pool.owners) {
-      yield send({
-        p1: P1.STAGE_CERTIFICATES,
-        p2: P2.OWNERS,
-        data: serializePoolOwner(owner),
-        expectedResponseLength: 0,
-      });
-    }
-
-    for (const relay of pool.relays) {
-      yield send({
-        p1: P1.STAGE_CERTIFICATES,
-        p2: P2.RELAYS,
-        data: serializePoolRelay(relay),
-        expectedResponseLength: 0,
-      });
-    }
-
-    yield send({
-      p1: P1.STAGE_CERTIFICATES,
-      p2: P2.METADATA,
-      data: serializePoolMetadata(pool.metadata),
-      expectedResponseLength: 0,
-    });
-
-    yield send({
-      p1: P1.STAGE_CERTIFICATES,
-      p2: P2.CONFIRMATION,
-      data: Buffer.alloc(0),
+      p2: P2.OWNERS,
+      data: serializePoolOwner(owner),
       expectedResponseLength: 0,
     });
   }
+
+  for (const relay of pool.relays) {
+    yield send({
+      p1: P1.STAGE_CERTIFICATES,
+      p2: P2.RELAYS,
+      data: serializePoolRelay(relay),
+      expectedResponseLength: 0,
+    });
+  }
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.METADATA,
+    data: serializePoolMetadata(pool.metadata),
+    expectedResponseLength: 0,
+  });
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.CONFIRMATION,
+    data: Buffer.alloc(0),
+    expectedResponseLength: 0,
+  });
+}
+
+function* signTx_addStakePoolRegistrationCertificateLegacy(
+  certificate: ParsedCertificate
+): Interaction<void> {
+  assert(certificate.type === CertificateType.STAKE_POOL_REGISTRATION, "invalid certificate type")
+
+  const enum P2 {
+    POOL_PARAMS = 0x30,
+    OWNERS = 0x31,
+    RELAYS = 0x32,
+    METADATA = 0x33,
+    CONFIRMATION = 0x34,
+  }
+
+  const pool = certificate.pool
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.POOL_PARAMS,
+    data: serializePoolInitialParamsLegacy(pool),
+    expectedResponseLength: 0,
+  });
+
+  for (const owner of pool.owners) {
+    yield send({
+      p1: P1.STAGE_CERTIFICATES,
+      p2: P2.OWNERS,
+      data: serializePoolOwner(owner),
+      expectedResponseLength: 0,
+    });
+  }
+
+  for (const relay of pool.relays) {
+    yield send({
+      p1: P1.STAGE_CERTIFICATES,
+      p2: P2.RELAYS,
+      data: serializePoolRelay(relay),
+      expectedResponseLength: 0,
+    });
+  }
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.METADATA,
+    data: serializePoolMetadata(pool.metadata),
+    expectedResponseLength: 0,
+  });
+
+  yield send({
+    p1: P1.STAGE_CERTIFICATES,
+    p2: P2.CONFIRMATION,
+    data: Buffer.alloc(0),
+    expectedResponseLength: 0,
+  });
 }
 
 function* signTx_addWithdrawal(
@@ -227,7 +325,7 @@ function* signTx_setTtl(
 }
 
 function* signTx_setAuxiliaryData(
-  auxiliaryData:  ParsedTxAuxiliaryData
+  auxiliaryData: ParsedTxAuxiliaryData
 ): Interaction<TxAuxiliaryDataSupplement | null> {
   const enum P2 {
     UNUSED = 0x00
@@ -261,7 +359,7 @@ function* signTx_setAuxiliaryData(
     yield send({
       p1: P1.STAGE_AUX_DATA,
       p2: P2.VOTING_KEY,
-      data: serializeCatalystRegistrationVotingKey(params.votingPublicKey), 
+      data: serializeCatalystRegistrationVotingKey(params.votingPublicKey),
       expectedResponseLength: 0,
     });
 
@@ -304,7 +402,7 @@ function* signTx_setAuxiliaryData(
 }
 
 function* signTx_setAuxiliaryData_before_v2_3(
-  auxiliaryData:  ParsedTxAuxiliaryData
+  auxiliaryData: ParsedTxAuxiliaryData
 ): Interaction<null> {
   const enum P2 {
     UNUSED = 0x00
@@ -413,6 +511,30 @@ function generateWitnessPaths(request: ParsedSigningRequest): ValidBIP32Path[] {
       assert(witnessOwner.type === PoolOwnerType.DEVICE_OWNED, "bad witness owner type")
       return [witnessOwner.path]
     }
+    case TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR: {
+      // we collect required witnesses for inputs and for the pool key
+      const witnessPaths: Record<string, ValidBIP32Path> = {}
+      // eslint-disable-next-line no-inner-declarations
+      function _insert(path: ValidBIP32Path) {
+        const pathKey = JSON.stringify(path);
+        witnessPaths[pathKey] = path
+      }
+
+      for (const input of tx.inputs) {
+        assert(input.path != null, "input missing path")
+        _insert(input.path)
+      }
+
+      // there should be a pool key given by path which will be used for the witness
+      assert(tx.certificates.length == 1, "bad certificates length");
+      const cert = tx.certificates[0]
+      assert(cert.type === CertificateType.STAKE_POOL_REGISTRATION, "bad certificate type");
+
+      assert(cert.pool.poolKey.type === PoolKeyType.DEVICE_OWNED, "bad pool key type")
+      _insert(cert.pool.poolKey.path)
+
+      return Object.values(witnessPaths)
+    }
     default: {
       assert(false, 'Bad signing mode')
     }
@@ -429,6 +551,17 @@ function ensureRequestSupportedByAppVersion(version: Version, request: ParsedSig
 
   if (request?.tx?.ttl === "0" && !getCompatibility(version).supportsZeroTtl) {
     throw new DeviceVersionUnsupported(`Zero TTL not supported by Ledger app version ${version}.`);
+  }
+
+  if (request?.signingMode === TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR && !getCompatibility(version).supportsOperationalCertificate) {
+    throw new DeviceVersionUnsupported(`Pool registration as operator not supported by Ledger app version ${version}.`);
+  }
+
+  const certificates = request?.tx?.certificates
+  const hasPoolRetirement = certificates && certificates.some(c => c.type === CertificateType.STAKE_POOL_RETIREMENT);
+
+  if (hasPoolRetirement && !getCompatibility(version).supportsPoolRetirement) {
+    throw new DeviceVersionUnsupported(`Pool retirement certificate not supported by Ledger app version ${version}.`);
   }
 }
 
@@ -471,7 +604,7 @@ export function* signTransaction(version: Version, request: ParsedSigningRequest
 
   // certificates
   for (const certificate of tx.certificates) {
-    yield* signTx_addCertificate(certificate);
+    yield* signTx_addCertificate(version, certificate);
   }
 
   // withdrawals

--- a/src/parsing/certificate.ts
+++ b/src/parsing/certificate.ts
@@ -3,7 +3,7 @@ import { InvalidDataReason } from "../errors/invalidDataReason";
 import type { ParsedCertificate, } from "../types/internal";
 import { CertificateType, KEY_HASH_LENGTH } from "../types/internal";
 import type { Certificate, } from "../types/public";
-import { parseBIP32Path, parseHexStringOfLength, validate } from "../utils/parse";
+import { parseBIP32Path, parseHexStringOfLength, parseUint64_str, validate } from "../utils/parse";
 import { parsePoolParams } from "./poolRegistration";
 
 export function parseCertificate(cert: Certificate): ParsedCertificate {
@@ -27,6 +27,13 @@ export function parseCertificate(cert: Certificate): ParsedCertificate {
             return {
                 type: cert.type,
                 pool: parsePoolParams(cert.params)
+            }
+        }
+        case CertificateType.STAKE_POOL_RETIREMENT: {
+            return {
+                type: cert.type,
+                path: parseBIP32Path(cert.params.poolKeyPath, InvalidDataReason.CERTIFICATE_MISSING_PATH),
+                retirementEpoch: parseUint64_str(cert.params.retirementEpoch, {}, InvalidDataReason.POOL_RETIREMENT_INVALID_RETIREMENT_EPOCH)
             }
         }
 

--- a/src/parsing/operationalCertificate.ts
+++ b/src/parsing/operationalCertificate.ts
@@ -1,0 +1,16 @@
+import { InvalidDataReason } from "../errors/invalidDataReason";
+import type { ParsedOperationalCertificate } from "../types/internal";
+import { KES_PUBLIC_KEY_LENGTH } from "../types/internal";
+import type { OperationalCertificate } from "../types/public";
+import { parseBIP32Path, parseHexStringOfLength, parseUint64_str } from "../utils/parse";
+
+export function parseOperationalCertificate(
+    operationalCertificate: OperationalCertificate
+): ParsedOperationalCertificate {
+    return {
+        kesPublicKeyHex: parseHexStringOfLength(operationalCertificate.kesPublicKeyHex, KES_PUBLIC_KEY_LENGTH, InvalidDataReason.OPERATIONAL_CERTIFICATE_INVALID_KES_KEY),
+        kesPeriod: parseUint64_str(operationalCertificate.kesPeriod, {}, InvalidDataReason.OPERATIONAL_CERTIFICATE_INVALID_KES_PERIOD),
+        issueCounter: parseUint64_str(operationalCertificate.issueCounter, {}, InvalidDataReason.OPERATIONAL_CERTIFICATE_INVALID_ISSUE_COUNTER),
+        coldKeyPath: parseBIP32Path(operationalCertificate.coldKeyPath, InvalidDataReason.OPERATIONAL_CERTIFICATE_INVALID_COLD_KEY_PATH),
+    }
+}

--- a/src/parsing/poolRegistration.ts
+++ b/src/parsing/poolRegistration.ts
@@ -1,18 +1,22 @@
 import { InvalidData } from "../errors";
 import { InvalidDataReason } from "../errors/invalidDataReason";
-import type { ParsedMargin, ParsedPoolMetadata, ParsedPoolOwner, ParsedPoolParams, ParsedPoolRelay, Uint16_t, Uint64_str, VarlenAsciiString } from "../types/internal";
-import { KEY_HASH_LENGTH, RelayType } from "../types/internal";
+import type { ParsedMargin, ParsedPoolKey, ParsedPoolMetadata, ParsedPoolOwner, ParsedPoolParams, ParsedPoolRelay, ParsedPoolRewardAccount, Uint16_t, Uint64_str, VarlenAsciiString } from "../types/internal";
+import { KEY_HASH_LENGTH, RelayType, REWARD_ACCOUNT_HEX_LENGTH } from "../types/internal";
 import type {
     MultiHostRelayParams,
+    PoolKey,
     PoolMetadataParams,
     PoolOwner,
     PoolRegistrationParams,
+    PoolRewardAccount,
     Relay,
     SingleHostHostnameRelayParams,
     SingleHostIpAddrRelayParams
 } from "../types/public";
 import {
-    PoolOwnerType
+    PoolKeyType,
+    PoolOwnerType,
+    PoolRewardAccountType,
 } from "../types/public";
 import { isHexStringOfLength, isString, isUint8, isUint16, parseAscii, parseBIP32Path, parseHexStringOfLength, parseIntFromStr, parseUint64_str, validate } from "../utils/parse";
 import { hex_to_buf } from "../utils/serialize";
@@ -39,15 +43,13 @@ function parseMargin(params: PoolRegistrationParams['margin']): ParsedMargin {
     }
 }
 
-
-
 export function parsePoolParams(params: PoolRegistrationParams): ParsedPoolParams {
-    const keyHashHex = parseHexStringOfLength(params.poolKeyHashHex, KEY_HASH_LENGTH, InvalidDataReason.POOL_REGISTRATION_INVALID_POOL_KEY_HASH)
+    const poolKey = parsePoolKey(params.poolKey)
     const vrfHashHex = parseHexStringOfLength(params.vrfKeyHashHex, 32, InvalidDataReason.POOL_REGISTRATION_INVALID_VRF_KEY_HASH)
     const pledge = parseUint64_str(params.pledge, { max: MAX_LOVELACE_SUPPLY_STR }, InvalidDataReason.POOL_REGISTRATION_INVALID_PLEDGE)
     const cost = parseUint64_str(params.cost, { max: MAX_LOVELACE_SUPPLY_STR }, InvalidDataReason.POOL_REGISTRATION_INVALID_COST)
     const margin = parseMargin(params.margin)
-    const rewardAccountHex = parseHexStringOfLength(params.rewardAccountHex, 29, InvalidDataReason.POOL_REGISTRATION_INVALID_REWARD_ACCOUNT)
+    const rewardAccount = parseRewardAccount(params.rewardAccount)
 
     const owners = params.poolOwners.map(owner => parsePoolOwnerParams(owner))
     const relays = params.relays.map(relay => parsePoolRelayParams(relay))
@@ -64,17 +66,46 @@ export function parsePoolParams(params: PoolRegistrationParams): ParsedPoolParam
     );
 
     return {
-        keyHashHex,
+        poolKey: poolKey,
         vrfHashHex,
         pledge,
         cost,
         margin,
-        rewardAccountHex,
+        rewardAccount,
         owners,
         relays,
         metadata
     }
 
+}
+
+function parsePoolKey(poolKey: PoolKey): ParsedPoolKey {
+    switch (poolKey.type) {
+        case PoolKeyType.DEVICE_OWNED: {
+            const params = poolKey.params
+            const path = parseBIP32Path(params.path, InvalidDataReason.POOL_KEY_INVALID_PATH);
+
+            return {
+                type: PoolKeyType.DEVICE_OWNED,
+                path,
+            }
+        }
+        case PoolKeyType.THIRD_PARTY: {
+            const params = poolKey.params
+            const hashHex = parseHexStringOfLength(
+                params.keyHashHex,
+                KEY_HASH_LENGTH,
+                InvalidDataReason.POOL_KEY_INVALID_KEY_HASH
+            );
+
+            return {
+                type: PoolKeyType.THIRD_PARTY,
+                hashHex
+            }
+        }
+        default:
+            throw new InvalidData(InvalidDataReason.POOL_KEY_INVALID_TYPE);
+    }
 }
 
 function parsePoolOwnerParams(poolOwner: PoolOwner): ParsedPoolOwner {
@@ -106,6 +137,34 @@ function parsePoolOwnerParams(poolOwner: PoolOwner): ParsedPoolOwner {
     }
 }
 
+function parseRewardAccount(poolRewardAccount: PoolRewardAccount): ParsedPoolRewardAccount {
+    switch (poolRewardAccount.type) {
+        case PoolRewardAccountType.DEVICE_OWNED: {
+            const params = poolRewardAccount.params
+            const path = parseBIP32Path(params.path, InvalidDataReason.POOL_REWARD_ACCOUNT_INVALID_PATH);
+
+            return {
+                type: PoolRewardAccountType.DEVICE_OWNED,
+                path,
+            }
+        }
+        case PoolRewardAccountType.THIRD_PARTY: {
+            const params = poolRewardAccount.params
+            const rewardAccountHex = parseHexStringOfLength(
+                params.rewardAccountHex,
+                REWARD_ACCOUNT_HEX_LENGTH,
+                InvalidDataReason.POOL_REWARD_ACCOUNT_INVALID_HEX
+            );
+
+            return {
+                type: PoolRewardAccountType.THIRD_PARTY,
+                rewardAccountHex
+            }
+        }
+        default:
+            throw new InvalidData(InvalidDataReason.POOL_REWARD_ACCOUNT_INVALID_TYPE);
+    }
+}
 
 function parsePort(portNumber: number, errMsg: InvalidDataReason): Uint16_t {
     validate(isUint16(portNumber), errMsg)

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,4 +1,4 @@
-import { AddressType, CertificateType, PoolOwnerType, RelayType, TransactionSigningMode, TxAuxiliaryDataType, TxOutputDestinationType } from './public'
+import { AddressType, CertificateType, PoolKeyType, PoolOwnerType, PoolRewardAccountType, RelayType, TransactionSigningMode, TxAuxiliaryDataType, TxOutputDestinationType } from './public'
 
 // Basic primitives
 export type VarlenAsciiString = string & { __type: 'ascii' }
@@ -15,12 +15,15 @@ export type Uint16_t = number & { __type: 'uint16_t' }
 export type Uint8_t = number & { __type: 'uint8_t' }
 
 // Reexport blockchain spec
-export { AddressType, CertificateType, RelayType, PoolOwnerType, TxAuxiliaryDataType, TransactionSigningMode, TxOutputDestinationType }
+export { AddressType, CertificateType, RelayType, PoolKeyType, PoolOwnerType, PoolRewardAccountType, TransactionSigningMode, TxAuxiliaryDataType, TxOutputDestinationType }
 export { Version, DeviceCompatibility } from './public'
 // Our types
 export const KEY_HASH_LENGTH = 28;
 export const TX_HASH_LENGTH = 32;
 export const AUXILIARY_DATA_HASH_LENGTH = 32;
+export const KES_PUBLIC_KEY_LENGTH = 32;
+export const REWARD_ACCOUNT_HEX_LENGTH = 29;
+export const ED25519_SIGNATURE_LENGTH = 64;
 
 export type ParsedCertificate = {
     type: CertificateType.STAKE_REGISTRATION
@@ -35,6 +38,10 @@ export type ParsedCertificate = {
 } | {
     type: CertificateType.STAKE_POOL_REGISTRATION
     pool: ParsedPoolParams
+} | {
+    type: CertificateType.STAKE_POOL_RETIREMENT
+    path: ValidBIP32Path
+    retirementEpoch: Uint64_str
 }
 
 export const TOKEN_POLICY_LENGTH = 28;
@@ -60,7 +67,7 @@ export const CATALYST_VOTING_PUBLIC_KEY_LENGTH = 32;
 
 export type CatalystVotingPublicKey = FixlenHexString<typeof CATALYST_VOTING_PUBLIC_KEY_LENGTH>
 
-export type  ParsedTxAuxiliaryData = {
+export type ParsedTxAuxiliaryData = {
     type: TxAuxiliaryDataType.ARBITRARY_HASH
     hashHex: FixlenHexString<typeof AUXILIARY_DATA_HASH_LENGTH>
 } | {
@@ -84,7 +91,7 @@ export type ParsedTransaction = {
     ttl: Uint64_str | null
     certificates: ParsedCertificate[]
     withdrawals: ParsedWithdrawal[]
-    auxiliaryData:  ParsedTxAuxiliaryData | null
+    auxiliaryData: ParsedTxAuxiliaryData | null
     validityIntervalStart: Uint64_str | null
 }
 
@@ -114,15 +121,24 @@ export type ParsedMargin = {
 
 
 export type ParsedPoolParams = {
-    keyHashHex: FixlenHexString<28>,
+    poolKey: ParsedPoolKey,
     vrfHashHex: FixlenHexString<32>,
     pledge: Uint64_str,
     cost: Uint64_str,
     margin: ParsedMargin,
-    rewardAccountHex: FixlenHexString<29>
+    rewardAccount: ParsedPoolRewardAccount,
     owners: ParsedPoolOwner[],
     relays: ParsedPoolRelay[],
     metadata: ParsedPoolMetadata | null
+}
+
+
+export type ParsedPoolKey = {
+    type: PoolKeyType.DEVICE_OWNED,
+    path: ValidBIP32Path
+} | {
+    type: PoolKeyType.THIRD_PARTY
+    hashHex: FixlenHexString<typeof KEY_HASH_LENGTH>
 }
 
 
@@ -133,6 +149,16 @@ export type ParsedPoolOwner = {
     type: PoolOwnerType.THIRD_PARTY
     hashHex: FixlenHexString<typeof KEY_HASH_LENGTH>
 }
+
+
+export type ParsedPoolRewardAccount = {
+    type: PoolRewardAccountType.DEVICE_OWNED,
+    path: ValidBIP32Path
+} | {
+    type: PoolRewardAccountType.THIRD_PARTY
+    rewardAccountHex: FixlenHexString<typeof REWARD_ACCOUNT_HEX_LENGTH>
+}
+
 
 export type ParsedPoolRelay = {
     type: RelayType.SINGLE_HOST_IP_ADDR,
@@ -231,3 +257,10 @@ export type ParsedOutput = {
 }
 
 export const ASSET_NAME_LENGTH_MAX = 32;
+
+export type ParsedOperationalCertificate = {
+    kesPublicKeyHex: FixlenHexString<typeof KES_PUBLIC_KEY_LENGTH>,
+    kesPeriod: Uint64_str,
+    issueCounter: Uint64_str,
+    coldKeyPath: ValidBIP32Path,
+}

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -70,6 +70,11 @@ export enum CertificateType {
      * @see [[PoolRegistrationParams]]
      */
     STAKE_POOL_REGISTRATION = 3,
+    /**
+     * Stake pool retirement certificate
+     * @see [[PoolRegistrationParams]]
+     */
+    STAKE_POOL_RETIREMENT = 4,
 }
 
 /**
@@ -217,6 +222,17 @@ export type AddressParamsReward = {
     stakingPath: BIP32Path
 }
 
+/** Operational certificate
+ *
+ * @category Basic types
+ */
+export type OperationalCertificate = {
+    kesPublicKeyHex: string,
+    kesPeriod: bigint_like,
+    issueCounter: bigint_like,
+    coldKeyPath: BIP32Path,
+}
+
 /**
  * Describes single transaction input (i.e. UTxO)
  * @category Basic types
@@ -332,7 +348,7 @@ export type TxOutputDestination = {
 }
 
 /**
- * Blochain pointer for Pointer addresses
+ * Blockchain pointer for Pointer addresses
  * @category Addresses
  * @see [[AddressParamsPointer]]
  */
@@ -340,6 +356,58 @@ export type BlockchainPointer = {
     blockIndex: number,
     txIndex: number,
     certificateIndex: number,
+};
+
+/**
+ * Type of a pool key in pool registration certificate.
+ * Ledger device needs to distinguish between keys which are owned by a third party
+ * or by this device if one needs to sign pool registration certificate as an operator.
+ * @see [[PoolKey]]
+ * @category Pool registration certificate
+ */
+export enum PoolKeyType {
+    /**
+     * Pool key is third party
+     * @see [[PoolKeyThirdPartyParams]]
+     */
+    THIRD_PARTY = 'third_party',
+    /**
+     * Pool key is owned by this device
+     * @see [[PoolKeyDeviceOwnedParams]]
+     */
+    DEVICE_OWNED = 'device_owned',
+}
+/**
+ * Represents pool cold key.
+ * @category Pool registration certificate
+ * @see [[PoolRegistrationParams]]
+ */
+export type PoolKey = {
+    type: PoolKeyType.THIRD_PARTY
+    params: PoolKeyThirdPartyParams
+} | {
+    type: PoolKeyType.DEVICE_OWNED
+    params: PoolKeyDeviceOwnedParams
+}
+
+/**
+ * Pool key is owned external party
+ * @category Pool registration certificate
+ * @see [[PoolKey]]
+ * @see [[PoolKeyType]]
+ */
+export type PoolKeyThirdPartyParams = {
+    keyHashHex: string,
+}
+
+/**
+ * Pool key is owned by Ledger device. Supply staking key path which should sign the certificate
+ * @category Pool registration certificate
+ * @see [[PoolKey]]
+ * @see [[PoolKeyType]]
+ */
+export type PoolKeyDeviceOwnedParams = {
+    path: BIP32Path,
 };
 
 /**
@@ -392,6 +460,58 @@ export type PoolOwnerThirdPartyParams = {
  */
 export type PoolOwnerDeviceOwnedParams = {
     stakingPath: BIP32Path,
+};
+
+/**
+ * Type of a reward account in pool registration certificate.
+ * Ledger device needs to distinguish between reward accounts which are owned by a third party
+ * or by this device if one needs to sign pool registration certificate as an owner.
+ * @see [[PoolRewardAccount]]
+ * @category Pool registration certificate
+ */
+export enum PoolRewardAccountType {
+    /**
+     * Pool reward account is third party
+     * @see [[PoolRewardAccountThirdPartyParams]]
+     */
+    THIRD_PARTY = 'third_party',
+    /**
+     * Pool reward account is owned by this device
+     * @see [[PoolRewardAccountDeviceOwnedParams]]
+     */
+    DEVICE_OWNED = 'device_owned',
+}
+/**
+ * Represents pool reward account.
+ * @category Pool registration certificate
+ * @see [[PoolRegistrationParams]]
+ */
+export type PoolRewardAccount = {
+    type: PoolRewardAccountType.THIRD_PARTY
+    params: PoolRewardAccountThirdPartyParams
+} | {
+    type: PoolRewardAccountType.DEVICE_OWNED
+    params: PoolRewardAccountDeviceOwnedParams
+}
+
+/**
+ * Pool reward account is external party
+ * @category Pool registration certificate
+ * @see [[PoolRewardAccount]]
+ * @see [[PoolRewardAccountType]]
+ */
+export type PoolRewardAccountThirdPartyParams = {
+    rewardAccountHex: string,
+}
+
+/**
+ * Pool owner is Ledger device. Supply staking key path for reward account
+ * @category Pool registration certificate
+ * @see [[PoolRewardAccount]]
+ * @see [[PoolRewardAccountType]]
+ */
+export type PoolRewardAccountDeviceOwnedParams = {
+    path: BIP32Path,
 };
 
 /**
@@ -452,7 +572,7 @@ export type Relay = {
 }
 
 /**
- * Pool registratin metadata
+ * Pool registration metadata
  * 
  * @category Pool registration certificate
  * @see [[PoolRegistrationParams]]
@@ -488,20 +608,34 @@ export type Margin = {
  * @see [[Certificate]]
  */
 export type PoolRegistrationParams = {
-    /** Pool cold key */
-    poolKeyHashHex: string,
+    poolKey: PoolKey,
     /** Pool vrf key */
     vrfKeyHashHex: string,
     /** Owner pledge */
     pledge: bigint_like,
     cost: bigint_like,
     margin: Margin,
-    /** Pool rewards account */
-    rewardAccountHex: string,
+    rewardAccount: PoolRewardAccount,
     poolOwners: Array<PoolOwner>,
     relays: Array<Relay>,
     metadata?: PoolMetadataParams | null,
 };
+
+/**
+ * Pool retirement certificate parameters
+ * @category Shelley
+ * @see [[Certificate]]
+ * */
+export type PoolRetirementParams = {
+    /**
+     * Path to the pool key
+     */
+    poolKeyPath: BIP32Path
+    /**
+     * Epoch after which the pool should be retired
+     */
+    retirementEpoch: bigint_like,
+}
 
 /**
  * Stake key registration certificate parameters
@@ -559,6 +693,9 @@ export type Certificate = {
 } | {
     type: CertificateType.STAKE_POOL_REGISTRATION
     params: PoolRegistrationParams
+} | {
+    type: CertificateType.STAKE_POOL_RETIREMENT
+    params: PoolRetirementParams
 }
 
 /**
@@ -630,6 +767,14 @@ export type DeviceCompatibility = {
      * (useful for dummy transactions to ensure invalidity)
      */
     supportsZeroTtl: boolean
+    /**
+     * Whether we support operational certificate signing
+     */
+    supportsOperationalCertificate: boolean
+    /**
+     * Whether we support pool retirement certificate
+     */
+    supportsPoolRetirement: boolean
 }
 
 /**
@@ -663,6 +808,15 @@ export type ExtendedPublicKey = {
     publicKeyHex: string,
     chainCodeHex: string,
 };
+
+/**
+ * Operational certificate signature
+ * @category Basic types
+ * @see [[Ada.signOperationalCertificate]]
+ */
+export type OperationalCertificateSignature = {
+    signatureHex: string
+}
 
 /**
  * Transaction witness.
@@ -885,10 +1039,23 @@ export enum TransactionSigningMode {
     POOL_REGISTRATION_AS_OWNER = 'pool_registration_as_owner',
 
     /**
-     * Reserved for future use
+     * Represents pool registration from the perspective of pool operator.
+     * 
+     * The transaction
+     * - *should* have valid `path` property on all `inputs`
+     * - *must* have single Pool registration certificate
+     * - *must* have a pool key of [[PoolKeyType.DEVICE_OWNED]] on that certificate
+     * - *must* have all owners of type [[PoolOwnerType.THIRD_PARTY]] on that certificate
+     * - *must not* have withdrawals
+     * 
+     * These restrictions are in place due to a possibility of maliciously signing *another* part of
+     * the transaction with the pool operator path as we are not displaying device-owned paths on the device screen.
+     * 
+     * The API witnesses
+     * - all non-null [[TxInput.path]] on `inputs`
+     * - [[PoolKeyDeviceOwnedParams.path]] found in pool registration
      */
-    __RESEVED_POOL_REGISTRATION_AS_OPERATOR = '__pool_registration_as_operator'
-
+    POOL_REGISTRATION_AS_OPERATOR = 'pool_registration_as_operator',
 }
 
 /**

--- a/test/integration/__fixtures__/deriveAddress.ts
+++ b/test/integration/__fixtures__/deriveAddress.ts
@@ -213,12 +213,12 @@ export const InvalidPathTestcases: InvalidPathTestcase[] = [
         errMsg: "Action rejected by Ledger's security policy"
     },
     {
-        testname: "too long",
+        testname: "invalid path",
         network: Networks.Fake,
         addressParams: {
             type: AddressType.BYRON,
             params: {
-                spendingPath: str_to_path("44'/1815'/1'/5/10'/1/2/3")
+                spendingPath: str_to_path("44'/1815'/1'/5/10'")
             }
         },
         errCls: DeviceStatusError,

--- a/test/integration/__fixtures__/getExtendedPublicKey.ts
+++ b/test/integration/__fixtures__/getExtendedPublicKey.ts
@@ -40,34 +40,8 @@ export const testsByron: TestCase[] = [
   },
 ]
 
-export const testsByronUnusual: TestCase[] = [
-  {
-    path: "44'/1815'/1'/0/10'/1/2/3",
-    expected: {
-      publicKey:
-        "8e54bc03fd01db1c2fa21e87780eb810838d2df024d33f1ea5e8507e7d4cf010",
-      chainCode:
-        "872301244debde31fe4d95df10cec5bda73e241683c5b958b53d19cf5a4c1286",
-      _privateKey:
-        "80e897e1a3903a34f28769c606f09ba97dabece097026fac26b975aa33e69d4128e357f2334d6f19f680469a7fa0cea0dfc1f5681ebdb6dcf125833814150b89",
-    },
-  },
-  {
-    path: "44'/1815'/1'/0/10'/1/2'/3",
-    expected: {
-      publicKey:
-        "be50763c781f6685a30872ff5471be5447793894b24d5ed6d95a62a17c5e0be1",
-      chainCode:
-        "edbc393fd9ad97665ab1e29f1523c2843e24639ec8a76778385a077e5153ecd0",
-      _privateKey:
-        "1843fa0d93d219fe32f828dcb0b099371efd76ad61835b882520b0b430e69d419478ef007b937df52bafdd6f00e3750649edf47ee9323d81cf128c1c2faa84d2",
-    },
-  },
-]
-
 export const testsShelley: TestCase[] = [
   // Shelley
-  // TODO supply missing values for deadbeefs?
   {
     path: "1852'/1815'/0'/0/1",
     expected: {
@@ -84,6 +58,30 @@ export const testsShelley: TestCase[] = [
         "66610efd336e1137c525937b76511fbcf2a0e6bcf0d340a67bcb39bc870d85e8",
       chainCode:
         "e977e956d29810dbfbda9c8ea667585982454e401c68578623d4b86bc7eb7b58",
-    }
+    },
   },
 ];
+
+export const testsShelleyUnusual: TestCase[] = [
+  {
+    path: "1852'/1815'/150'/0/10'",
+    expected: {
+      publicKey:
+        "cfd898d89110dae7c762e77cf8f58b02ab0ac6cd142781c7bb6bbf62df0c53ac",
+      chainCode:
+        "964fd2c6038d5e5b1aef40b25ad673e8169b7a55ba29845c17e3c4df7af72cee",
+    },
+  },
+]
+
+export const testsColdKeys: TestCase[] = [
+  {
+    path: "1853'/1815'/0'/0'",
+    expected: {
+      publicKey:
+        "3d7e84dca8b4bc322401a2cc814af7c84d2992a22f99554fe340d7df7910768d",
+      chainCode:
+        "1e2a47754207da3069f90241fbf3b8742c367e9028e5f3f85ae3660330b4f5b7",
+    },
+  },
+]

--- a/test/integration/__fixtures__/signOperationalCertificate.ts
+++ b/test/integration/__fixtures__/signOperationalCertificate.ts
@@ -1,0 +1,23 @@
+import type { OperationalCertificate, OperationalCertificateSignature } from "../../../src/Ada";
+import { str_to_path } from "../../../src/utils";
+
+export type TestCase = {
+  testname: string,
+  operationalCertificate: OperationalCertificate,
+  expected: OperationalCertificateSignature,
+}
+
+export const tests: TestCase[] = [
+  {
+    testname: "basic operational certificate",
+    operationalCertificate: {
+      kesPublicKeyHex: "3d24bc547388cf2403fd978fc3d3a93d1f39acf68a9c00e40512084dc05f2822",
+      kesPeriod: "47",
+      issueCounter: "42",
+      coldKeyPath: str_to_path("1853'/1815'/0'/0'")
+    },
+    expected: {
+      signatureHex: "ce8d7cab55217ed17f1cceb8cb487dcbe6172fdb5794cc26f78c2f1d2495598e72beb6209f113562f9488ef6e81e3e8f758ea072c3cf9c17095868f2e9213f0a"
+    }
+  }
+]

--- a/test/integration/__fixtures__/signTx.ts
+++ b/test/integration/__fixtures__/signTx.ts
@@ -244,17 +244,29 @@ export const outputs: Record<
             amount: "7878754",
           },
           {
-            assetNameHex: "",
+            assetNameHex: "456c204e69c3b16f",
             amount: "1234",
           },
         ],
       },
       {
-        policyIdHex: "75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+        // fingerprints taken from CIP 14 draft
+        policyIdHex: "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
         tokens: [
           {
-            assetNameHex: "7564247542686911",
-            amount: "47",
+            // fingerprint: asset17jd78wukhtrnmjh3fngzasxm8rck0l2r4hhyyt
+            assetNameHex: "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
+            amount: "1"
+          },
+          {
+            // fingerprint: asset1pkpwyknlvul7az0xx8czhl60pyel45rpje4z8w
+            assetNameHex: "0000000000000000000000000000000000000000000000000000000000000000",
+            amount: "2"
+          },
+          {
+            // fingerprint: asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3
+            assetNameHex: "",
+            amount: "3"
           },
         ],
       },
@@ -862,15 +874,15 @@ export const testsMary: TestcaseMary[] = [
       ...maryBase,
       outputs: [outputs.multiassetManyTokens, outputs.internalBaseWithStakingPath],
     },
-    txBody: "a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff821904d2a2581c95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39a24874652474436f696e1a00783862401904d2581c75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39a1487564247542686911182f8258390114c16d7f43243bd81478e68b9db53a8528fd4fb1078d58d54a7f11241d227aefa4b773149170885aadba30aab3127cc611ddbc4999def61c1a006ca79302182a030a08182f",
+    txBody: "a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff821904d2a2581c95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39a24874652474436f696e1a0078386248456c204e69c3b16f1904d2581c75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39a1487564247542686911182f8258390114c16d7f43243bd81478e68b9db53a8528fd4fb1078d58d54a7f11241d227aefa4b773149170885aadba30aab3127cc611ddbc4999def61c1a006ca79302182a030a08182f",
     result: {
       txHashHex:
-        "76e0af0eb9eb19b374d002b0eedbb9175eb3e5c5327db376be0ae94a4fcf4b84",
+        "e5d45f693b4466e2b2a71fa87c119fabb08f6491d7926968bc3d17d74501981c",
       witnesses: [
         {
           path: str_to_path("1852'/1815'/0'/0/0"),
           witnessSignatureHex:
-            "562497549b44d34926598d8a6511c4b58da0cb8da77033b633983f2897dbd59f1d45a4bef987574d83ebe74a016ccab042d0462df813e86896db624d221a5207",
+            "6ab398a53f71db868e61cb8f71a2009c5e702b1eda83c23d94858a24f69880bedd78f53319feb4d9dc10021069301f5245d2e52cf5c5e12ca9584d4cc41e6d05",
         },
       ],
       auxiliaryDataSupplement: null,

--- a/test/integration/__fixtures__/signTxPoolRegistration.ts
+++ b/test/integration/__fixtures__/signTxPoolRegistration.ts
@@ -1,13 +1,29 @@
-import type { Certificate, MultiHostRelayParams, PoolMetadataParams, PoolOwner, PoolRegistrationParams, Relay, SignedTransactionData, SingleHostHostnameRelayParams, Transaction, TxInput, TxOutput, Withdrawal } from "../../../src/Ada";
+import type { Certificate, MultiHostRelayParams, PoolKey, PoolMetadataParams, PoolOwner, PoolRegistrationParams, PoolRewardAccount, Relay, SignedTransactionData, SingleHostHostnameRelayParams, Transaction, TxInput, TxOutput, Withdrawal } from "../../../src/Ada";
+import { PoolKeyType, PoolRewardAccountType } from "../../../src/Ada";
 import { CertificateType, InvalidDataReason, Networks, PoolOwnerType, RelayType, TxOutputDestinationType, utils } from "../../../src/Ada";
 import { str_to_path } from "../../../src/utils/address";
 
-export const inputs: Record<'utxo', TxInput> = {
-  utxo: {
+export const inputs: Record<
+  | 'utxoNoPath'
+  | 'utxoWithPath0'
+  | 'utxoWithPath1'
+  , TxInput
+> = {
+  utxoNoPath: {
     txHashHex:
       "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
     outputIndex: 0,
     path: null,
+  },
+  utxoWithPath0: {
+    txHashHex: "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+    outputIndex: 0,
+    path: str_to_path("1852'/1815'/0'/0/0"),
+  },
+  utxoWithPath1: {
+    txHashHex: "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+    outputIndex: 0,
+    path: str_to_path("1852'/1815'/0'/0/1"),
   },
 };
 
@@ -30,7 +46,7 @@ export const outputs: Record<'external', TxOutput> = {
 
 const txBase: Transaction = {
   network: Networks.Mainnet,
-  inputs: [inputs.utxo],
+  inputs: [inputs.utxoNoPath],
   outputs: [outputs.external],
   fee: 42,
   ttl: 10,
@@ -84,6 +100,25 @@ export const invalidPoolMetadataTestcases: Array<{ testName: string, metadata: P
   }
 ]
 
+const poolKeys: Record<
+  | 'poolKeyPath'
+  | 'poolKeyHash'
+  , PoolKey
+> = {
+  poolKeyPath: {
+    type: PoolKeyType.DEVICE_OWNED,
+    params: {
+      path: str_to_path("1853'/1815'/0'/0'"),
+    }
+  },
+  poolKeyHash: {
+    type: PoolKeyType.THIRD_PARTY,
+    params: {
+      keyHashHex: "13381d918ec0283ceeff60f7f4fc21e1540e053ccf8a77307a7a32ad"
+    }
+  }
+}
+
 const stakingHashOwners: Record<
   | 'owner0'
   | 'owner1'
@@ -133,6 +168,25 @@ const poolOwnerVariationSet = {
   twoPathOwners: [stakingPathOwners.owner0, stakingPathOwners.owner1],
   twoCombinedOwners: [stakingPathOwners.owner0, stakingHashOwners.owner0],
 };
+
+const poolRewardAccounts: Record<
+  | 'poolRewardAccountPath'
+  | 'poolRewardAccountHash'
+  , PoolRewardAccount
+> = {
+  poolRewardAccountPath: {
+    type: PoolRewardAccountType.DEVICE_OWNED,
+    params: {
+      path: str_to_path("1852'/1815'/3'/2/0"),
+    }
+  },
+  poolRewardAccountHash: {
+    type: PoolRewardAccountType.THIRD_PARTY,
+    params: {
+      rewardAccountHex: "e1794d9b3408c9fb67b950a48a0690f070f117e9978f7fc1d120fc58ad"
+    }
+  }
+}
 
 const relays: Record<
   | 'singleHostIPV4Relay0'
@@ -270,7 +324,7 @@ const relayVariationSet = {
 };
 
 export const defaultPoolRegistration: PoolRegistrationParams = {
-  poolKeyHashHex: "13381d918ec0283ceeff60f7f4fc21e1540e053ccf8a77307a7a32ad",
+  poolKey: poolKeys.poolKeyHash,
   vrfKeyHashHex:
     "07821cd344d7fd7e3ae5f2ed863218cb979ff1d59e50c4276bdc479b0d084450",
   pledge: "50000000000",
@@ -279,8 +333,7 @@ export const defaultPoolRegistration: PoolRegistrationParams = {
     numerator: 3,
     denominator: 100,
   },
-  rewardAccountHex:
-    "e1794d9b3408c9fb67b950a48a0690f070f117e9978f7fc1d120fc58ad",
+  rewardAccount: poolRewardAccounts.poolRewardAccountHash,
   poolOwners: poolOwnerVariationSet.singlePathOwner,
   relays: relayVariationSet.singleHostIPV4Relay,
   metadata: {
@@ -292,6 +345,7 @@ export const defaultPoolRegistration: PoolRegistrationParams = {
 
 export const certificates: Record<
   | 'stakeDelegation'
+  | 'stakeRegistration'
   | 'poolRegistrationDefault'
   | 'poolRegistrationMixedOwners'
   | 'poolRegistrationMixedOwnersAllRelays'
@@ -300,6 +354,10 @@ export const certificates: Record<
   | 'poolRegistrationNoRelays'
   | 'poolRegistrationNoMetadata'
   | 'poolRegistrationWrongMargin'
+  | 'poolRegistrationOperatorNoOwnersNoRelays'
+  | 'poolRegistrationOperatorMultipleOwnersAllRelays'
+  | 'poolRegistrationOperatorOneOwnerOperatorNoRelays'
+  | 'poolRetirement'
   , Certificate
 > = {
   // for negative tests 
@@ -309,6 +367,12 @@ export const certificates: Record<
       path: str_to_path("1852'/1815'/0'/2/0"),
       poolKeyHashHex: "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973",
     }
+  },
+  stakeRegistration: {
+    type: 0,
+    params: {
+      path: str_to_path("1852'/1815'/0'/2/0"),
+    },
   },
   poolRegistrationDefault: {
     type: CertificateType.STAKE_POOL_REGISTRATION,
@@ -369,6 +433,41 @@ export const certificates: Record<
       },
     },
   },
+  poolRegistrationOperatorNoOwnersNoRelays: {
+    type: CertificateType.STAKE_POOL_REGISTRATION,
+    params: {
+      ...defaultPoolRegistration,
+      poolKey: poolKeys.poolKeyPath,
+      poolOwners: poolOwnerVariationSet.noOwners,
+      relays: relayVariationSet.noRelays,
+    },
+  },
+  poolRegistrationOperatorOneOwnerOperatorNoRelays: {
+    type: CertificateType.STAKE_POOL_REGISTRATION,
+    params: {
+      ...defaultPoolRegistration,
+      poolKey: poolKeys.poolKeyPath,
+      rewardAccount: poolRewardAccounts.poolRewardAccountPath,
+      poolOwners: poolOwnerVariationSet.singleHashOwner,
+      relays: relayVariationSet.noRelays,
+    },
+  },
+  poolRegistrationOperatorMultipleOwnersAllRelays: {
+    type: CertificateType.STAKE_POOL_REGISTRATION,
+    params: {
+      ...defaultPoolRegistration,
+      poolKey: poolKeys.poolKeyPath,
+      poolOwners: poolOwnerVariationSet.twoHashOwners,
+      relays: relayVariationSet.allRelays,
+    },
+  },
+  poolRetirement: {
+    type: CertificateType.STAKE_POOL_RETIREMENT,
+    params: {
+      poolKeyPath: str_to_path("1853'/1815'/0'/0'"),
+      retirementEpoch: "10",
+    }
+  },
 };
 
 export const invalidCertificates: Array<{ testName: string, poolRegistrationCertificate: Certificate, expectedReject: string }> = [
@@ -404,17 +503,25 @@ export const invalidCertificates: Array<{ testName: string, poolRegistrationCert
       },
     },
     expectedReject: InvalidDataReason.SIGN_MODE_POOL_OWNER__SINGLE_DEVICE_OWNER_REQUIRED
-  }
+  },
 ]
 
-export const withdrawals: Record<'withdrawal0', Withdrawal> = {
+export const withdrawals: Record<
+  | 'withdrawal0'
+  | 'withdrawal1'
+  , Withdrawal
+> = {
   withdrawal0: {
     path: str_to_path("1852'/1815'/0'/2/0"),
     amount: "111",
   },
+  withdrawal1: {
+    path: str_to_path("1852'/1815'/1'/2/0"),
+    amount: "112"
+  },
 };
 
-type Testcase = {
+export type Testcase = {
   testname: string
   tx: Transaction
   result: SignedTransactionData
@@ -581,6 +688,120 @@ export const poolRegistrationTestcases: Testcase[] = [
           path: str_to_path("1852'/1815'/0'/2/0"),
           witnessSignatureHex:
             "91c09ad95d5d0f87f61a62e2f5e2dda4245eb4011887a04a53bdf085282002ccc712718e855e36a30cfcf7ecd43bcdc795aa87647be9c716b65e7fcf376e0503",
+        },
+      ],
+      auxiliaryDataSupplement: null,
+    },
+  },
+]
+
+export const poolRegistrationOperatorTestcases: Testcase[] = [
+  {
+    testname: "Should correctly witness pool registration with no owners and no relays",
+    tx: {
+      ...txBase,
+      inputs: [inputs.utxoWithPath0],
+      certificates: [certificates.poolRegistrationOperatorNoOwnersNoRelays],
+    },
+    result: {
+      // WARNING: only as computed by ledger, not verified with cardano-cli
+      txHashHex:
+        "75a57a27893443eb7bb6e4746b6d52ba74c401ece0d2a2570322d6b7d07c29a7",
+      witnesses: [
+        {
+          path: str_to_path("1852'/1815'/0'/0/0"),
+          witnessSignatureHex:
+            "2bff91cbd14ae53a2d476bd27306a7117d705c4fb58248af4f9b86c770991ea9785a39924d824a75b9ee0632b52c4267e6afec41e206a03b4753c5a397275807"
+        },
+        {
+          path: str_to_path("1853'/1815'/0'/0'"),
+          witnessSignatureHex:
+            "a92f621f48c785103b1dab862715beef0f0dc2408d0668422286a1dbc268db9a32cacd3b689a0c6af32ab2ac5057caac13910f09363e2d2db0dde4a27b2b5a09"
+        },
+      ],
+      auxiliaryDataSupplement: null,
+    },
+  },
+  {
+    testname: "Should correctly witness pool registration with one owner and no relays",
+    tx: {
+      ...txBase,
+      inputs: [inputs.utxoWithPath0],
+      certificates: [certificates.poolRegistrationOperatorOneOwnerOperatorNoRelays],
+    },
+    result: {
+      // WARNING: only as computed by ledger, not verified with cardano-cli
+      txHashHex:
+        "486d70234b174592fffb1e750fe9580e4d88a39cd7668514b244a885251e5344",
+      witnesses: [
+        {
+          path: str_to_path("1852'/1815'/0'/0/0"),
+          witnessSignatureHex:
+            "12776e69a6ea50ad42cdf0e164afc5a8b4fab612868ab990ead677ba4ced3ea2ad25b27ef5b27296add22c7378689a8572eb10ce24483b2ab8140b8aa5b1f70c"
+        },
+        {
+          path: str_to_path("1853'/1815'/0'/0'"),
+          witnessSignatureHex:
+            "d8851757cf6dc978fc4b3db42111124e83e99d58739a21ecf23c6b5de316a8fe6d03767df45e62ad7b64872a73a68427ce83f6a856ebd196897e4d96c3173d06"
+        },
+      ],
+      auxiliaryDataSupplement: null,
+    },
+  },
+  {
+    testname: "Should correctly witness pool registration with multiple owners and all relays",
+    tx: {
+      ...txBase,
+      inputs: [inputs.utxoWithPath0],
+      certificates: [certificates.poolRegistrationOperatorMultipleOwnersAllRelays],
+    },
+    result: {
+      // WARNING: only as computed by ledger, not verified with cardano-cli
+      txHashHex:
+        "7ece5d431b09770f2e24c190e96c3884866ba4c9cd3292d4b42d286af5f3f872",
+      witnesses: [
+        {
+          path: str_to_path("1852'/1815'/0'/0/0"),
+          witnessSignatureHex:
+            "9f6da51173411ba82e76695ccf7c222f1df7444b0bbc1af354800acf244a4eaf72e95853406918e3ef461569fe99b39e33164ab440510f75df06e4ff89ca9107"
+        },
+        {
+          path: str_to_path("1853'/1815'/0'/0'"),
+          witnessSignatureHex:
+            "8957a7768bc9389cd7ab6fa3b3e2fa089785715a5298f9cb38abf99a6e0da5bef734c4862ca7948fb69575ccb9ed8ae1d92cc971742f674632f6f03e22c5b103"
+        },
+      ],
+      auxiliaryDataSupplement: null,
+    },
+  },
+]
+
+export const poolRetirementTestCases: Testcase[] = [
+  {
+    testname: "Should correctly witness pool retirement combined with another certifciate",
+    tx: {
+      ...txBase,
+      inputs: [inputs.utxoWithPath0],
+      certificates: [certificates.poolRetirement, certificates.stakeRegistration],
+    },
+    result: {
+      // WARNING: only as computed by ledger, not verified with cardano-cli
+      txHashHex: "da65ca8c5a9e4e1a8dd3c7f623e7e0e13c4f23d7ef2ae7bdd9e5edd654ec5656",
+      witnesses: [
+        {
+          path: str_to_path("1852'/1815'/0'/0/0"),
+          witnessSignatureHex:
+            "1238a6c4baf2dd0732c4b377db24ce3169196bcf64bd058a41cb0bfb4eefa4269384501645e8fc40be6d3bcc0272a51d1f36d7f06a9f0a55bfc2797bff573f0c"
+        },
+        {
+          path: str_to_path("1853'/1815'/0'/0'"),
+          witnessSignatureHex:
+            "ce19e55d2a6f00ed7627e164f7c4df5686e60e0f26e51280b7459e149ff520cb9adbbccb846d3852d30e492ffccdb40f9315966917e939c7621fbbc80ab3cc02"
+        },
+        {
+          path: str_to_path("1852'/1815'/0'/2/0"),
+          witnessSignatureHex:
+            "09e73628850d3b69e19ba3b95009ab389a6def0b19d6d4b8db84033cd989676384b1cf73dbe65bf1b2e373346e8159a2dc5c92f2c86f6b56827edf541604f30c"
         },
       ],
       auxiliaryDataSupplement: null,

--- a/test/integration/getExtendedPublicKey.test.ts
+++ b/test/integration/getExtendedPublicKey.test.ts
@@ -6,7 +6,7 @@ import { DeviceStatusError } from "../../src/Ada";
 import { str_to_path } from "../../src/utils/address";
 import { getAda } from "../test_utils";
 import type { TestCase } from "./__fixtures__/getExtendedPublicKey";
-import { testsByron, testsByronUnusual, testsShelley } from "./__fixtures__/getExtendedPublicKey";
+import { testsByron, testsColdKeys, testsShelley, testsShelleyUnusual } from "./__fixtures__/getExtendedPublicKey";
 chai.use(chaiAsPromised)
 
 describe("getExtendedPublicKey", async () => {
@@ -35,13 +35,15 @@ describe("getExtendedPublicKey", async () => {
     it('byron', async () => {
       await test(testsByron)
     })
-    it('byron unusual', async () => {
-      await test(testsByronUnusual)
-    })
     it('shelley', async () => {
       await test(testsShelley)
     })
-
+    it('shelley unusual', async () => {
+      await test(testsShelleyUnusual)
+    })
+    it('cold keys', async () => {
+      await test(testsColdKeys)
+    })
   });
 
   describe("Should successfully get several extended public keys", async () => {
@@ -58,17 +60,22 @@ describe("getExtendedPublicKey", async () => {
     }
 
     it('starting with a usual one', async () => {
-      await test([...testsByron, ...testsShelley])
+      await test([...testsByron, ...testsShelley, ...testsColdKeys])
     })
 
-    it('starting with unusual one', async () => {
-      await test([...testsByronUnusual, ...testsByron, ...testsShelley])
+    it('starting with an unusual one', async () => {
+      await test([...testsShelleyUnusual, ...testsByron, ...testsColdKeys, ...testsShelley])
     })
   })
 
   describe("Should reject invalid paths", () => {
     it('path shorter than 3 indexes', async () => {
       const promise = ada.getExtendedPublicKey({ path: str_to_path("44'/1815'") })
+      await expect(promise).to.be.rejectedWith(DeviceStatusError, "Action rejected by Ledger's security policy")
+    })
+
+    it('path not matching cold key structure', async () => {
+      const promise = ada.getExtendedPublicKey({ path: str_to_path("1853'/1900'/0'/0/0") })
       await expect(promise).to.be.rejectedWith(DeviceStatusError, "Action rejected by Ledger's security policy")
     })
   });

--- a/test/integration/getVersion.test.ts
+++ b/test/integration/getVersion.test.ts
@@ -18,13 +18,15 @@ describe("getVersion", async () => {
     const { version, compatibility } = await ada.getVersion();
 
     expect(version.major).to.equal(2);
-    expect(version.minor).to.equal(3);
+    expect(version.minor).to.equal(4);
     expect(compatibility).to.deep.equal({
       isCompatible: true,
       recommendedVersion: null,
       supportsMary: true,
       supportsCatalystRegistration: true,
       supportsZeroTtl: true,
+      supportsOperationalCertificate: true,
+      supportsPoolRetirement: true,
     })
   });
 });

--- a/test/integration/signOperationalCertificate.test.ts
+++ b/test/integration/signOperationalCertificate.test.ts
@@ -1,0 +1,27 @@
+import chai, { expect } from "chai"
+import chaiAsPromised from "chai-as-promised"
+
+import type Ada from "../../src/Ada";
+import { getAda, } from "../test_utils";
+import { tests } from "./__fixtures__/signOperationalCertificate";
+chai.use(chaiAsPromised)
+
+describe("signOperationalCertificate", async () => {
+  let ada: Ada = {} as Ada;
+
+  beforeEach(async () => {
+    ada = await getAda();
+  });
+
+  afterEach(async () => {
+    await (ada as any).t.close();
+  });
+
+  for (const { testname, operationalCertificate, expected } of tests) {
+    it(testname, async () => {
+      const response = await ada.signOperationalCertificate(operationalCertificate);
+
+      expect(response).to.deep.equal(expected);
+    })
+  }
+});

--- a/test/integration/signTxPoolRegistration.test.ts
+++ b/test/integration/signTxPoolRegistration.test.ts
@@ -5,6 +5,7 @@ import type Ada from "../../src/Ada";
 import type { Certificate, Transaction } from "../../src/Ada";
 import { CertificateType, InvalidDataReason, TransactionSigningMode } from "../../src/Ada";
 import { getAda, Networks } from "../test_utils";
+import type { Testcase } from "./__fixtures__/signTxPoolRegistration";
 import {
   certificates,
   defaultPoolRegistration,
@@ -13,7 +14,9 @@ import {
   invalidPoolMetadataTestcases,
   invalidRelayTestcases,
   outputs,
+  poolRegistrationOperatorTestcases,
   poolRegistrationTestcases,
+  poolRetirementTestCases,
   withdrawals,
 } from "./__fixtures__/signTxPoolRegistration";
 chai.use(chaiAsPromised)
@@ -29,12 +32,18 @@ describe("signTxPoolRegistrationOK", async () => {
     await (ada as any).t.close();
   });
 
-  for (const { testname, tx, result: expectedResult } of poolRegistrationTestcases) {
-    it(testname, async () => {
-      const response = await ada.signTransaction({ tx, signingMode: TransactionSigningMode.POOL_REGISTRATION_AS_OWNER });
-      expect(response).to.deep.equal(expectedResult);
-    })
+  const test = (testcases: Testcase[], signingMode: TransactionSigningMode) => {
+    for (const { testname, tx, result: expectedResult } of testcases) {
+      it(testname, async () => {
+        const response = await ada.signTransaction({ tx, signingMode });
+        expect(response).to.deep.equal(expectedResult);
+      })
+    }
   }
+
+  test(poolRegistrationTestcases, TransactionSigningMode.POOL_REGISTRATION_AS_OWNER)
+  test(poolRegistrationOperatorTestcases, TransactionSigningMode.POOL_REGISTRATION_AS_OPERATOR)
+  test(poolRetirementTestCases, TransactionSigningMode.ORDINARY_TRANSACTION)
 });
 
 // ======================================== negative tests (tx should be rejected) ===============================
@@ -52,7 +61,7 @@ describe("signTxPoolRegistrationReject", async () => {
 
   const txBase: Omit<Transaction, 'certificates'> = {
     network: Networks.Mainnet,
-    inputs: [inputs.utxo],
+    inputs: [inputs.utxoNoPath],
     outputs: [outputs.external],
     fee: 42,
     ttl: 10,


### PR DESCRIPTION
This is a rebased version of #24. Added functionality should be equivalent to that of #24.

Tested with the Ledger app `operatorapp` branch and all the tests are passing except catalyst/auxiliary data related tests:
- `Should correctly sign tx with nonempty auxiliary data`
- `Should correctly sign tx with non-reasonable account and address`
- `Mary era transaction with zero fee, TTL and validity interval start`
- `Should correctly sign tx with Catalyst voting key registration metadata with base address`
- `Should correctly sign tx with Catalyst voting key registration metadata with stake address`