### PR TITLE
Temporarily remove asset groups canonical ordering validation

### DIFF
--- a/src/parsing/transaction.ts
+++ b/src/parsing/transaction.ts
@@ -64,12 +64,14 @@ function parseAssetGroup(assetGroup: AssetGroup): ParsedAssetGroup {
     }
 
     const assetNamesHex = parsedAssetGroup.tokens.map(t => t.assetNameHex)
-    const sortedAssetNames = [...assetNamesHex].sort( (n1, n2) => {
-        if (n1.length == n2.length) return n1.localeCompare(n2)
-        else return n1.length - n2.length
-    })
-    validate(JSON.stringify(assetNamesHex) == JSON.stringify(sortedAssetNames), InvalidDataReason.OUTPUT_INVALID_ASSET_GROUP_ORDERING)
     validate(assetNamesHex.length == new Set(assetNamesHex).size, InvalidDataReason.OUTPUT_INVALID_ASSET_GROUP_NOT_UNIQUE)
+
+    // enforcing of asset order is removed for now and will be added back after the ordering is properly defined by a CIP
+    // const sortedAssetNames = [...assetNamesHex].sort( (n1, n2) => {
+    //     if (n1.length == n2.length) return n1.localeCompare(n2)
+    //     else return n1.length - n2.length
+    // })
+    // validate(JSON.stringify(assetNamesHex) == JSON.stringify(sortedAssetNames), InvalidDataReason.OUTPUT_INVALID_ASSET_GROUP_ORDERING)
 
     return parsedAssetGroup
 }
@@ -79,9 +81,11 @@ function parseTokenBundle(tokenBundle: AssetGroup[]): ParsedAssetGroup[] {
     const parsedTokenBundle = tokenBundle.map(ag => parseAssetGroup(ag))
 
     const policyIds = parsedTokenBundle.map(ag => ag.policyIdHex)
-    const sortedPolicyIds = [...policyIds].sort()
-    validate(JSON.stringify(policyIds) == JSON.stringify(sortedPolicyIds), InvalidDataReason.OUTPUT_INVALID_TOKEN_BUNDLE_ORDERING)
     validate(policyIds.length == new Set(policyIds).size, InvalidDataReason.OUTPUT_INVALID_TOKEN_BUNDLE_NOT_UNIQUE)
+
+    // enforcing of policies order is removed for now and will be added back after the ordering is properly defined by a CIP
+    // const sortedPolicyIds = [...policyIds].sort()
+    // validate(JSON.stringify(policyIds) == JSON.stringify(sortedPolicyIds), InvalidDataReason.OUTPUT_INVALID_TOKEN_BUNDLE_ORDERING)
 
     return parsedTokenBundle
 }

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -277,12 +277,6 @@ export type Token = {
  */
 export type AssetGroup = {
     policyIdHex: string,
-    /**
-     * The keys must be sorted lowest value to highest to reflect a valid canonical CBOR.
-     * The sorting rules (as described in the [CBOR RFC](https://datatracker.ietf.org/doc/html/rfc7049#section-3.9)) are:
-     *  * if two keys have different lengths, the shorter one sorts earlier;
-     *  * if two keys have the same length, the one with the lower value in lexical order sorts earlier.
-     */
     tokens: Array<Token>,
 };
 
@@ -299,10 +293,6 @@ export type TxOutput = {
     amount: bigint_like
     /**
      * Additional assets sent to the output.
-     * If not null, the keys must be sorted lowest value to highest to reflect a canonical CBOR.
-     * The sorting rules (as described in the [CBOR RFC](https://datatracker.ietf.org/doc/html/rfc7049#section-3.9)) are:
-     *  * if two keys have different lengths, the shorter one sorts earlier;
-     *  * if two keys have the same length, the one with the lower value in lexical order sorts earlier.
      */
     tokenBundle?: Array<AssetGroup> | null
     /**

--- a/test/integration/__fixtures__/signTx.ts
+++ b/test/integration/__fixtures__/signTx.ts
@@ -175,10 +175,10 @@ export const outputs: Record<
   | 'multiassetManyTokens'
   | 'multiassetChange'
   | 'multiassetBigNumber'
-  | 'multiassetInvalidAssetGroupOrdering'
+//   | 'multiassetInvalidAssetGroupOrdering'
   | 'multiassetAssetGroupsNotUnique'
-  | 'multiassetInvalidTokenOrderingSameLength'
-  | 'multiassetInvalidTokenOrderingDifferentLengths'
+//   | 'multiassetInvalidTokenOrderingSameLength'
+//   | 'multiassetInvalidTokenOrderingDifferentLengths'
   | 'multiassetTokensNotUnique'
   , TxOutput
 > = {
@@ -307,30 +307,31 @@ export const outputs: Record<
             },
         ],
     },
-    multiassetInvalidAssetGroupOrdering: {
-        destination: destinations.multiassetThirdParty,
-        amount: "1234",
-        tokenBundle: [
-            {
-                policyIdHex: "75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
-                tokens: [
-                    {
-                        assetNameHex: "7564247542686911",
-                        amount: "47",
-                    },
-                ],
-            },
-            {
-                policyIdHex: "71a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
-                tokens: [
-                    {
-                        assetNameHex: "7564247542686911",
-                        amount: "47",
-                    },
-                ],
-            },
-        ],
-    },
+    // enforcing of asset groups order is removed for now and will be added back after the ordering is properly defined by a CIP
+    // multiassetInvalidAssetGroupOrdering: {
+    //     destination: destinations.multiassetThirdParty,
+    //     amount: "1234",
+    //     tokenBundle: [
+    //         {
+    //             policyIdHex: "75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+    //             tokens: [
+    //                 {
+    //                     assetNameHex: "7564247542686911",
+    //                     amount: "47",
+    //                 },
+    //             ],
+    //         },
+    //         {
+    //             policyIdHex: "71a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+    //             tokens: [
+    //                 {
+    //                     assetNameHex: "7564247542686911",
+    //                     amount: "47",
+    //                 },
+    //             ],
+    //         },
+    //     ],
+    // },
     multiassetAssetGroupsNotUnique: {
         destination: destinations.multiassetThirdParty,
         amount: "1234",
@@ -355,44 +356,45 @@ export const outputs: Record<
             },
         ],
     },
-    multiassetInvalidTokenOrderingSameLength: {
-        destination: destinations.multiassetThirdParty,
-        amount: "1234",
-        tokenBundle: [
-            {
-                policyIdHex: "75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
-                tokens: [
-                    {
-                        assetNameHex: "7564247542686911",
-                        amount: "47",
-                    },
-                    {
-                        assetNameHex: "74652474436f696e",
-                        amount: "7878754",
-                    },
-                ],
-            },
-        ],
-    },
-    multiassetInvalidTokenOrderingDifferentLengths: {
-        destination: destinations.multiassetThirdParty,
-        amount: "1234",
-        tokenBundle: [
-            {
-                policyIdHex: "75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
-                tokens: [
-                    {
-                        assetNameHex: "7564247542686911",
-                        amount: "47",
-                    },
-                    {
-                        assetNameHex: "756424754268",
-                        amount: "7878754",
-                    },
-                ],
-            },
-        ],
-    },
+    // enforcing of asset order is removed for now and will be added back after the ordering is properly defined by a CIP
+    // multiassetInvalidTokenOrderingSameLength: {
+    //     destination: destinations.multiassetThirdParty,
+    //     amount: "1234",
+    //     tokenBundle: [
+    //         {
+    //             policyIdHex: "75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+    //             tokens: [
+    //                 {
+    //                     assetNameHex: "7564247542686911",
+    //                     amount: "47",
+    //                 },
+    //                 {
+    //                     assetNameHex: "74652474436f696e",
+    //                     amount: "7878754",
+    //                 },
+    //             ],
+    //         },
+    //     ],
+    // },
+    // multiassetInvalidTokenOrderingDifferentLengths: {
+    //     destination: destinations.multiassetThirdParty,
+    //     amount: "1234",
+    //     tokenBundle: [
+    //         {
+    //             policyIdHex: "75a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+    //             tokens: [
+    //                 {
+    //                     assetNameHex: "7564247542686911",
+    //                     amount: "47",
+    //                 },
+    //                 {
+    //                     assetNameHex: "756424754268",
+    //                     amount: "7878754",
+    //                 },
+    //             ],
+    //         },
+    //     ],
+    // },
     multiassetTokensNotUnique: {
         destination: destinations.multiassetThirdParty,
         amount: "1234",
@@ -1210,14 +1212,15 @@ export type InvalidTokenBundleOrderingTestcase = {
 }
 
 export const testsInvalidTokenBundleOrdering: InvalidTokenBundleOrderingTestcase[] = [
-    {
-        testname: "Reject tx where asset groups are not ordered",
-        tx: {
-            ...maryBase,
-            outputs: [outputs.multiassetInvalidAssetGroupOrdering],
-        },
-        rejectReason: InvalidDataReason.OUTPUT_INVALID_TOKEN_BUNDLE_ORDERING,
-    },
+    // enforcing of asset groups order is removed for now and will be added back after the ordering is properly defined by a CIP
+    // {
+    //     testname: "Reject tx where asset groups are not ordered",
+    //     tx: {
+    //         ...maryBase,
+    //         outputs: [outputs.multiassetInvalidAssetGroupOrdering],
+    //     },
+    //     rejectReason: InvalidDataReason.OUTPUT_INVALID_TOKEN_BUNDLE_ORDERING,
+    // },
     {
         testname: "Reject tx where asset groups are not unique",
         tx: {
@@ -1226,22 +1229,23 @@ export const testsInvalidTokenBundleOrdering: InvalidTokenBundleOrderingTestcase
         },
         rejectReason: InvalidDataReason.OUTPUT_INVALID_TOKEN_BUNDLE_NOT_UNIQUE,
     },
-    {
-        testname: "Reject tx where tokens within an asset group are not ordered - alphabetical",
-        tx: {
-            ...maryBase,
-            outputs: [outputs.multiassetInvalidTokenOrderingSameLength],
-        },
-        rejectReason: InvalidDataReason.OUTPUT_INVALID_ASSET_GROUP_ORDERING,
-    },
-    {
-        testname: "Reject tx where tokens within an asset group are not ordered - length",
-        tx: {
-            ...maryBase,
-            outputs: [outputs.multiassetInvalidTokenOrderingDifferentLengths],
-        },
-        rejectReason: InvalidDataReason.OUTPUT_INVALID_ASSET_GROUP_ORDERING,
-    },
+    // enforcing of asset order is removed for now and will be added back after the ordering is properly defined by a CIP
+    // {
+    //     testname: "Reject tx where tokens within an asset group are not ordered - alphabetical",
+    //     tx: {
+    //         ...maryBase,
+    //         outputs: [outputs.multiassetInvalidTokenOrderingSameLength],
+    //     },
+    //     rejectReason: InvalidDataReason.OUTPUT_INVALID_ASSET_GROUP_ORDERING,
+    // },
+    // {
+    //     testname: "Reject tx where tokens within an asset group are not ordered - length",
+    //     tx: {
+    //         ...maryBase,
+    //         outputs: [outputs.multiassetInvalidTokenOrderingDifferentLengths],
+    //     },
+    //     rejectReason: InvalidDataReason.OUTPUT_INVALID_ASSET_GROUP_ORDERING,
+    // },
     {
         testname: "Reject tx where tokens within an asset group are not unique",
         tx: {


### PR DESCRIPTION
Validation is being removed because it is causing problems for cardano-hw-cli users. Also the exact canonical ordering is yet to be defined.

I've decided to just comment out the code so it'll be easier to add later.