### PR TITLE
Force higher version of ansi-regex for dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,12 @@
     "test-integration": "yarn mocha --timeout 3600000 -r ts-node/register test/integration/**/*.test.ts",
     "test-unit": "yarn mocha -r ts-node/register test/unit/**/*.test.ts",
     "//": "run single test by specifying --grep <name> parameter in test-integration"
+  },
+  "resolutions": {
+    "chalk/ansi-regex": "<6.0.6",
+    "prettier-eslint/**/ansi-regex": "<6.0.0",
+    "eslint/**/ansi-regex": "<6.0.0",
+    "@ledgerhq/hw-transport-node-hid/**/ansi-regex": "<6.0.0",
+    "mocha/**/ansi-regex": "<6.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -385,25 +385,15 @@ ansi-colors@^4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+ansi-regex@<6.0.0, ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
-
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+ansi-regex@<6.0.6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1636,6 +1626,11 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
   integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
 
+int64-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-1.0.1.tgz#c78d841b444cadf036cd04f8683696c740f15dca"
+  integrity sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw==
+
 internal-slot@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
@@ -1644,11 +1639,6 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
-
-int64-buffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-1.0.1.tgz#c78d841b444cadf036cd04f8683696c740f15dca"
-  integrity sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw==
 
 interpret@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
Motivation: fix yarn audit errors breaking the pipeline on `yarn audit`. It's done selectively to make sure that any non-dev dependency doesn't get accidentally impacted in the future (https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/)

Why I'm not forcing a version higher than 6.0.0 is that it seems to fail on some ES module error as ansi-regex apparently changed to it in version 6. When linting I got the following error

```
yarn run v1.22.10
$ yarn eslint . --max-warnings=0
$ /home/circleci/repo/node_modules/.bin/eslint . --max-warnings=0
There was a problem loading formatter: /home/circleci/repo/node_modules/eslint/lib/cli-engine/formatters/stylish
Error: Must use import to load ES Module: /home/circleci/repo/node_modules/ansi-regex/index.js
require() of ES modules is not supported.
require() of /home/circleci/repo/node_modules/ansi-regex/index.js from /home/circleci/repo/node_modules/eslint/node_modules/strip-ansi/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename /home/circleci/repo/node_modules/ansi-regex/index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /home/circleci/repo/node_modules/ansi-regex/package.json.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Exited with code exit status 2
```

and ansi-regex did a backport to address it - version 5.0.1: https://github.com/chalk/ansi-regex/releases/tag/v5.0.1

I'm just forcing that version across all affected packages as they depended on an older version of ansi-regex than 6 where the ESM transition was done (so they have no reason to depend on that)

Testing: I didn't run the device tests, please check if it's working as expected