### PR TITLE
Eslint missing semicolon

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,9 @@
     "@typescript-eslint/consistent-type-imports": [
       "warn",
       { "prefer": "type-imports" }
+    ],
+    "@typescript-eslint/member-delimiter-style": [
+      "warn"
     ]
   },
   "overrides": [


### PR DESCRIPTION
We deal with multiline declarations inconsistently, this rule fixes that (but `yarn lint --fix` needs to be run after we merge it).