### PR TITLE
Update circleci ssh key fingerprint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            - 86:62:3c:0a:fb:47:d3:70:45:54:a7:99:58:b8:8e:32
+            - e4:d2:8d:f4:aa:02:4a:ea:ed:72:00:62:1e:f7:9b:bc
       - run:
           name: Setup git
           command: |


### PR DESCRIPTION
Update to new ssh key fingerprint for docs deployment

Fingerprint can be found here: https://app.circleci.com/settings/project/github/vacuumlabs/ledgerjs-cardano-shelley/ssh?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fvacuumlabs%2Fledgerjs-cardano-shelley

Can be tested by merging into master and/or pushing a temporary commit enabling the docs deployment also on this branch