### PR TITLE
Fix/getversion signmesage fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   "resolutions": {
     "chalk/ansi-regex": "<6.0.6",
     "mocha/diff": "^8.0.3",
-    "mocha/serialize-javascript": "^7.0.3"
+    "mocha/serialize-javascript": "^7.0.3",
+    "lodash": "^4.18.1"
   },
   "packageManager": "yarn@4.13.0"
 }

--- a/test/integration/__fixtures__/signMessage.ts
+++ b/test/integration/__fixtures__/signMessage.ts
@@ -121,7 +121,7 @@ export const tests: TestCase[] = [
   },
   {
     testName:
-      'msg07: Should correctly sign a 198 bytes long non-hashed ascii message with keyhash as address field',
+      'msg07: Should correctly sign a 198 bytes long hashed ascii message with keyhash as address field',
     signMessageData: {
       messageHex: '6869'.repeat(99),
       signingPath: str_to_path("1852'/1815'/0'/3/0"),
@@ -139,7 +139,7 @@ export const tests: TestCase[] = [
   },
   {
     testName:
-      'msg08: Should correctly sign a 99 bytes long non-hashed hex message with keyhash as address field',
+      'msg08: Should correctly sign a 99 bytes long hashed hex message with keyhash as address field',
     signMessageData: {
       messageHex: 'de'.repeat(99),
       signingPath: str_to_path("1852'/1815'/0'/3/0"),

--- a/test/integration/getVersion.test.ts
+++ b/test/integration/getVersion.test.ts
@@ -20,10 +20,10 @@ describe('getVersion', () => {
 
     const {version, compatibility} = await ada.getVersion()
 
-    expect(version.major).to.equal(7)
-    expect(version.minor).to.equal(3)
+    expect(version.major).to.equal(8)
+    expect(version.minor).to.equal(0)
 
-    expect(version.flags.isDebug).to.equal(true)
+    expect(version.flags.isDebug).to.equal(false)
 
     expect(compatibility).to.deep.equal({
       isCompatible: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,10 +3957,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# `getVersion` + `signMessage`: fixture/metadata fixes

## getVersion
Device returns `8.0.0, isDebug: false` but test expects `7.3.x, isDebug: true`.
Update version expectations to match app v8.

## signMessage
msg07 and msg08 have `testName` saying "non-hashed" but `hashPayload: true`.
The names are misleading — fix the test name strings.

## Fixed audit vulnerabilities