### PR TITLE
Fix/deriveaddress getpubkey rejects

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   "resolutions": {
     "chalk/ansi-regex": "<6.0.6",
     "mocha/diff": "^8.0.3",
-    "mocha/serialize-javascript": "^7.0.3"
+    "mocha/serialize-javascript": "^7.0.3",
+    "lodash": "^4.18.1"
   },
   "packageManager": "yarn@4.13.0"
 }

--- a/src/errors/deviceStatusError.ts
+++ b/src/errors/deviceStatusError.ts
@@ -9,7 +9,8 @@ export const DeviceStatusCodes = {
   ERR_INVALID_DATA: 0x6e07 as const,
   ERR_INVALID_BIP_PATH: 0x6e08 as const,
   ERR_REJECTED_BY_USER: 0x6e09 as const,
-  ERR_REJECTED_BY_POLICY: 0x6e10 as const,
+  //ERR_REJECTED_BY_POLICY: 0x6e10 as const,
+  ERR_REJECTED_BY_POLICY: 0x6982 as const,
   ERR_DEVICE_LOCKED: 0x6e11 as const,
   ERR_UNSUPPORTED_ADDRESS_TYPE: 0x6e12 as const,
 

--- a/src/errors/deviceStatusError.ts
+++ b/src/errors/deviceStatusError.ts
@@ -9,7 +9,6 @@ export const DeviceStatusCodes = {
   ERR_INVALID_DATA: 0x6e07 as const,
   ERR_INVALID_BIP_PATH: 0x6e08 as const,
   ERR_REJECTED_BY_USER: 0x6e09 as const,
-  //ERR_REJECTED_BY_POLICY: 0x6e10 as const,
   ERR_REJECTED_BY_POLICY: 0x6982 as const,
   ERR_DEVICE_LOCKED: 0x6e11 as const,
   ERR_UNSUPPORTED_ADDRESS_TYPE: 0x6e12 as const,

--- a/test/integration/__fixtures__/deriveAddress.ts
+++ b/test/integration/__fixtures__/deriveAddress.ts
@@ -23,7 +23,7 @@ export const byronTestCases: ByronTestCase[] = [
     addressParams: {
       type: AddressType.BYRON,
       params: {
-        spendingPath: str_to_path("44'/1815'/1'/0/55'"),
+        spendingPath: str_to_path("44'/1815'/1'/0/55'"), // WARN
       },
     },
     result: 'Ae2tdPwUPEZELF6oijm8VFmhWpujnNzyG2zCf4RxfhmWqQKHo2drRD5Uhah',
@@ -34,7 +34,7 @@ export const byronTestCases: ByronTestCase[] = [
     addressParams: {
       type: AddressType.BYRON,
       params: {
-        spendingPath: str_to_path("44'/1815'/1'/0/12'"),
+        spendingPath: str_to_path("44'/1815'/1'/0/12'"), // WARN
       },
     },
     result: 'Ae2tdPwUPEYyiPZzoMSN9GJMNZnn3S6ZAErrezee9s1bH6tjaX6m9Cyf3Wy',
@@ -68,7 +68,7 @@ export const byronTestCases: ByronTestCase[] = [
     addressParams: {
       type: AddressType.BYRON,
       params: {
-        spendingPath: str_to_path("44'/1815'/1'/0/12'"),
+        spendingPath: str_to_path("44'/1815'/1'/0/12'"), // WARN
       },
     },
     result: '2657WMsDfac5GGdHMD6sR22tyhmFvuPrBZ79hvEvuisyUK9XCcB3nu8JecKuCXEkr',
@@ -376,7 +376,7 @@ export const shelleyTestCases: ShelleyTestCase[] = [
     addressParams: {
       type: AddressType.ENTERPRISE_KEY,
       params: {
-        spendingPath: str_to_path("1852'/1815'/101'/0/1"),
+        spendingPath: str_to_path("1852'/1815'/101'/0/1"), // WARN
       },
     },
     result: 'addr1vv6dcymepkghuyt0za9jxg5hn89art9y8yjcvhxclxdhnds25ctky',
@@ -549,7 +549,7 @@ export const shelleyTestCases: ShelleyTestCase[] = [
     addressParams: {
       type: AddressType.REWARD_KEY,
       params: {
-        stakingPath: str_to_path("1852'/1815'/101'/2/1"),
+        stakingPath: str_to_path("1852'/1815'/101'/2/1"), // WARN
       },
     },
     result: 'stake_test1up0umv478zejdvynrddaddjzcztnmm2phsqs77cghyuah6qnjw5hh',
@@ -560,7 +560,7 @@ export const shelleyTestCases: ShelleyTestCase[] = [
     addressParams: {
       type: AddressType.REWARD_KEY,
       params: {
-        stakingPath: str_to_path("1852'/1815'/0'/2/20000000"),
+        stakingPath: str_to_path("1852'/1815'/0'/2/20000000"), // WARN
       },
     },
     result: 'stake_test1urgn94qu0ewtt6f7l4sp6jm5vjv5u3gktevzy46s2qn92yshap4ze',
@@ -571,7 +571,7 @@ export const shelleyTestCases: ShelleyTestCase[] = [
     addressParams: {
       type: AddressType.REWARD_KEY,
       params: {
-        stakingPath: str_to_path("1852'/1815'/300'/2/0"),
+        stakingPath: str_to_path("1852'/1815'/300'/2/0"), // WARN
       },
     },
     result: 'stake1u08h6dxajsaatnakylrd4pdhfrv7z3lkzgsq60fhvejux0gpcrd2j',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,10 +3957,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# `deriveAddress` + `getExtendedPublicKey`: reject error code

## Updating ERR_REJECTED_BY_POLICY to 0x6982
App v8 changed the error code for security policy violations.

## Fixed audit vulnerabilities