### PR TITLE
Cm unrestricted test

### DIFF
--- a/src/Ada.ts
+++ b/src/Ada.ts
@@ -29,6 +29,11 @@ import {getSerial} from './interactions/getSerial'
 import {getVersion} from './interactions/getVersion'
 import {getCompatibility} from './validation/deviceCapabilities'
 import {runTests} from './interactions/runTests'
+import {
+  debugSetSettings,
+  type ConfirmedDebugSettings,
+  type DebugSettings,
+} from './interactions/debugSetSettings'
 import {showAddress} from './interactions/showAddress'
 import {signCVote} from './interactions/signCVote'
 import {signOperationalCertificate} from './interactions/signOperationalCertificate'
@@ -220,6 +225,7 @@ export class Ada {
       'signMessage',
       'signCIP36Vote',
       'runTests',
+      'debugSetSettings',
       'deriveNativeScriptHash',
     ]
     this.transport.decorateAppAPIMethods(this, methods, scrambleKey)
@@ -299,6 +305,21 @@ export class Ada {
   *_runTests(): Interaction<void> {
     const version = yield* getVersion()
     return yield* runTests(version)
+  }
+
+  /**
+   * Sets device settings directly via APDU (DEBUG app build only).
+   * Returns the confirmed settings written to NVM.
+   */
+  async debugSetSettings(
+    settings: DebugSettings,
+  ): Promise<ConfirmedDebugSettings> {
+    return interact(this._debugSetSettings(settings), this._send)
+  }
+
+  /** @ignore */
+  *_debugSetSettings(settings: DebugSettings): Interaction<ConfirmedDebugSettings> {
+    return yield* debugSetSettings(settings)
   }
 
   /**

--- a/src/Ada.ts
+++ b/src/Ada.ts
@@ -21,7 +21,8 @@ import type Transport from '@ledgerhq/hw-transport'
 import {StatusWordV7, StatusWordV8} from './errors/deviceStatusError'
 import {DeviceStatusError, ErrorBase} from './errors'
 import {InvalidDataReason} from './errors/invalidDataReason'
-import type {Interaction, SendParams} from './interactions/common/types'
+import {interact} from './interactions/common/interact'
+import type {Interaction, SendFn, SendParams} from './interactions/common/types'
 import {deriveAddress} from './interactions/deriveAddress'
 import {deriveNativeScriptHash} from './interactions/deriveNativeScriptHash'
 import {getExtendedPublicKeys} from './interactions/getExtendedPublicKeys'
@@ -29,11 +30,6 @@ import {getSerial} from './interactions/getSerial'
 import {getVersion} from './interactions/getVersion'
 import {getCompatibility} from './validation/deviceCapabilities'
 import {runTests} from './interactions/runTests'
-import {
-  debugSetSettings,
-  type ConfirmedDebugSettings,
-  type DebugSettings,
-} from './interactions/debugSetSettings'
 import {showAddress} from './interactions/showAddress'
 import {signCVote} from './interactions/signCVote'
 import {signOperationalCertificate} from './interactions/signOperationalCertificate'
@@ -140,7 +136,7 @@ function wrapConvertDeviceStatusError<TArgs extends unknown[], TResult>(
  */
 
 /** @ignore */
-export type SendFn = (params: SendParams) => Promise<Buffer>
+export type {SendFn}
 
 // It can happen that we try to send a message to the device
 // when the device thinks it is still in a middle of previous APDU stream.
@@ -181,21 +177,11 @@ function wrapRetryStillInCall<TArgs extends unknown[], TResult>(
   })
 }
 
-async function interact<T>(
+function interactWithDevice<T>(
   interaction: Interaction<T>,
   send: SendFn,
 ): Promise<T> {
-  let cursor = interaction.next()
-  let first = true
-  while (!cursor.done) {
-    const apdu = cursor.value
-    const res = first
-      ? await wrapRetryStillInCall(send)(apdu)
-      : await send(apdu)
-    first = false
-    cursor = interaction.next(res)
-  }
-  return cursor.value
+  return interact(interaction, send, wrapRetryStillInCall(send))
 }
 
 /**
@@ -225,7 +211,6 @@ export class Ada {
       'signMessage',
       'signCIP36Vote',
       'runTests',
-      'debugSetSettings',
       'deriveNativeScriptHash',
     ]
     this.transport.decorateAppAPIMethods(this, methods, scrambleKey)
@@ -264,7 +249,7 @@ export class Ada {
    *
    */
   async getVersion(): Promise<GetVersionResponse> {
-    const version = await interact(this._getVersion(), this._send)
+    const version = await interactWithDevice(this._getVersion(), this._send)
     return {version, compatibility: getCompatibility(version)}
   }
 
@@ -285,7 +270,7 @@ export class Ada {
    *
    */
   async getSerial(): Promise<GetSerialResponse> {
-    return interact(this._getSerial(), this._send)
+    return interactWithDevice(this._getSerial(), this._send)
   }
 
   /** @ignore */
@@ -298,28 +283,13 @@ export class Ada {
    * Runs unit tests on the device (DEVEL app build only)
    */
   async runTests(): Promise<void> {
-    return interact(this._runTests(), this._send)
+    return interactWithDevice(this._runTests(), this._send)
   }
 
   /** @ignore */
   *_runTests(): Interaction<void> {
     const version = yield* getVersion()
     return yield* runTests(version)
-  }
-
-  /**
-   * Sets device settings directly via APDU (DEBUG app build only).
-   * Returns the confirmed settings written to NVM.
-   */
-  async debugSetSettings(
-    settings: DebugSettings,
-  ): Promise<ConfirmedDebugSettings> {
-    return interact(this._debugSetSettings(settings), this._send)
-  }
-
-  /** @ignore */
-  *_debugSetSettings(settings: DebugSettings): Interaction<ConfirmedDebugSettings> {
-    return yield* debugSetSettings(settings)
   }
 
   /**
@@ -343,7 +313,7 @@ export class Ada {
       parseBIP32Path(path, InvalidDataReason.INVALID_PATH),
     )
 
-    return interact(this._getExtendedPublicKeys(parsed), this._send)
+    return interactWithDevice(this._getExtendedPublicKeys(parsed), this._send)
   }
 
   /** @ignore */
@@ -374,7 +344,7 @@ export class Ada {
   }: DeriveAddressRequest): Promise<DeriveAddressResponse> {
     const parsedParams = parseAddress(network, address)
 
-    return interact(this._deriveAddress(parsedParams), this._send)
+    return interactWithDevice(this._deriveAddress(parsedParams), this._send)
   }
 
   /** @ignore */
@@ -392,7 +362,7 @@ export class Ada {
   async showAddress({network, address}: ShowAddressRequest): Promise<void> {
     const parsedParams = parseAddress(network, address)
 
-    return interact(this._showAddress(parsedParams), this._send)
+    return interactWithDevice(this._showAddress(parsedParams), this._send)
   }
 
   /** @ignore */
@@ -406,7 +376,7 @@ export class Ada {
   ): Promise<SignTransactionResponse> {
     const parsedRequest = parseSignTransactionRequest(request)
 
-    return interact(this._signTx(parsedRequest), this._send)
+    return interactWithDevice(this._signTx(parsedRequest), this._send)
   }
 
   /** @ignore */
@@ -420,7 +390,7 @@ export class Ada {
   ): Promise<SignOperationalCertificateResponse> {
     const parsedOperationalCertificate = parseOperationalCertificate(request)
 
-    return interact(
+    return interactWithDevice(
       this._signOperationalCertificate(parsedOperationalCertificate),
       this._send,
     )
@@ -437,7 +407,7 @@ export class Ada {
   async signMessage(request: SignMessageRequest): Promise<SignMessageResponse> {
     const parsedMsgData = parseMessageData(request)
 
-    return interact(this._signMessage(parsedMsgData), this._send)
+    return interactWithDevice(this._signMessage(parsedMsgData), this._send)
   }
 
   /** @ignore */
@@ -451,7 +421,7 @@ export class Ada {
   ): Promise<SignCIP36VoteResponse> {
     const parsedCVote = parseCVote(request)
 
-    return interact(this._signCIP36Vote(parsedCVote), this._send)
+    return interactWithDevice(this._signCIP36Vote(parsedCVote), this._send)
   }
 
   /** @ignore */
@@ -473,7 +443,7 @@ export class Ada {
     const parsedDisplayFormat =
       parseNativeScriptHashDisplayFormat(displayFormat)
 
-    return interact(
+    return interactWithDevice(
       this._deriveNativeScriptHash(parsedScript, parsedDisplayFormat),
       this._send,
     )

--- a/src/interactions/common/interact.ts
+++ b/src/interactions/common/interact.ts
@@ -1,0 +1,17 @@
+import type {Interaction, SendFn} from './types'
+
+export async function interact<T>(
+  interaction: Interaction<T>,
+  send: SendFn,
+  sendFirst: SendFn = send,
+): Promise<T> {
+  let cursor = interaction.next()
+  let first = true
+  while (!cursor.done) {
+    const apdu = cursor.value
+    const response = await (first ? sendFirst : send)(apdu)
+    first = false
+    cursor = interaction.next(response)
+  }
+  return cursor.value
+}

--- a/src/interactions/common/types.ts
+++ b/src/interactions/common/types.ts
@@ -6,4 +6,6 @@ export type SendParams = {
   expectedResponseLength?: number
 }
 
+export type SendFn = (params: SendParams) => Promise<Buffer>
+
 export type Interaction<RetValue> = Generator<SendParams, RetValue, Buffer>

--- a/src/interactions/debugSetSettings.ts
+++ b/src/interactions/debugSetSettings.ts
@@ -1,0 +1,44 @@
+import {INS} from './common/ins'
+import type {Interaction, SendParams} from './common/types'
+
+export type DebugSettings = {
+  expertMode: boolean
+  silentPubkeyExport?: boolean
+  blindSigning?: boolean
+}
+
+export type ConfirmedDebugSettings = {
+  expertMode: boolean
+  silentPubkeyExport: boolean
+  blindSigning: boolean
+}
+
+const send = (params: {
+  p1: number
+  p2: number
+  data: Buffer
+  expectedResponseLength?: number
+}): SendParams => ({ins: INS.RUN_TESTS, ...params})
+
+export function* debugSetSettings(
+  settings: DebugSettings,
+): Interaction<ConfirmedDebugSettings> {
+  const data = Buffer.from([
+    settings.expertMode ? 0x01 : 0x00,
+    settings.silentPubkeyExport ? 0x01 : 0x00,
+    settings.blindSigning ? 0x01 : 0x00,
+  ])
+
+  const response = yield send({
+    p1: 0x00,
+    p2: 0x00,
+    data,
+    expectedResponseLength: 3,
+  })
+
+  return {
+    expertMode: response[0] === 0x01,
+    silentPubkeyExport: response[1] === 0x01,
+    blindSigning: response[2] === 0x01,
+  }
+}

--- a/test/debugSetSettings.ts
+++ b/test/debugSetSettings.ts
@@ -1,5 +1,5 @@
-import {INS} from './common/ins'
-import type {Interaction, SendParams} from './common/types'
+import {INS} from '../src/interactions/common/ins'
+import type {Interaction, SendParams} from '../src/interactions/common/types'
 
 export type DebugSettings = {
   expertMode: boolean

--- a/test/integration/__fixtures__/signTx.ts
+++ b/test/integration/__fixtures__/signTx.ts
@@ -677,7 +677,8 @@ export const testsShelleyWithCertificates: SignTxTestCase[] = [
     },
   },
   {
-    testName: 'Sign_tx_unrestricted_with_pool_retirement_combined_with_stake_registration',
+    testName:
+      'Sign_tx_unrestricted_with_pool_retirement_combined_with_stake_registration',
     appVersion: {unsupportedInAppXS: true, supportedSinceV8: true},
     requiresExpertMode: true,
     tx: {

--- a/test/integration/__fixtures__/signTx.ts
+++ b/test/integration/__fixtures__/signTx.ts
@@ -675,6 +675,61 @@ export const testsShelleyWithCertificates: SignTxTestCase[] = [
       auxiliaryDataSupplement: null,
     },
   },
+  {
+    testName: 'Sign_tx_unrestricted_with_pool_retirement_combined_with_stake_registration',
+    appVersion: {unsupportedInAppXS: true},
+    tx: {
+      ...shelleyBase,
+      inputs: [
+        {
+          txHashHex:
+            '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+          outputIndex: 0,
+          path: str_to_path("1852'/1815'/0'/0/0"),
+        },
+      ],
+      certificates: [
+        {
+          type: CertificateType.STAKE_POOL_RETIREMENT,
+          params: {
+            poolKeyPath: str_to_path("1853'/1815'/0'/0'"),
+            retirementEpoch: '10',
+          },
+        },
+        {
+          type: CertificateType.STAKE_REGISTRATION,
+          params: {
+            stakeCredential: {
+              type: CredentialParamsType.KEY_PATH,
+              keyPath: str_to_path("1852'/1815'/0'/2/0"),
+            },
+          },
+        },
+      ],
+    },
+    signingMode: TransactionSigningMode.UNRESTRICTED_TRANSACTION,
+    additionalWitnessPaths: [],
+    txBody:
+      'a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182582b82d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c25611a002dd2e802182a030a04828304581cdbfee4665e58c8f8e9b9ff02b17f32e08a42c855476a5d867c2737b70a82008200581c1d227aefa4b773149170885aadba30aab3127cc611ddbc4999def61c',
+    expectedResult: {
+      // WARNING: only as computed by ledger, not verified with cardano-cli
+      txHashHex:
+        '70aea83c8e5e9a3e0ec92860d5bd4750c34911193f092a96b9da6906d6ea6247',
+      witnesses: [
+        {
+          path: str_to_path("1852'/1815'/0'/0/0"),
+          witnessSignatureHex:
+            '8212cdabe1be514fdc21e02a2b405ce284ebbce0208a5c2b289dac662bf87fb4c2d18237c66761e285d78ee76cc26b7517718e641174d69f49737a49e9482607',
+        },
+        {
+          path: str_to_path("1853'/1815'/0'/0'"),
+          witnessSignatureHex:
+            '9386c2545e2671497daf95db93be1386690a4f884547a60f2913ef8a9e61486ba068d7477e1cd712f8d9cc20778d9e71b72eda96c9394c2f3111c61803f9a70d',
+        },
+      ],
+      auxiliaryDataSupplement: null,
+    },
+  },
 ]
 
 export const testsConwayWithCertificates: SignTxTestCase[] = [

--- a/test/integration/__fixtures__/signTx.ts
+++ b/test/integration/__fixtures__/signTx.ts
@@ -34,6 +34,7 @@ export type SignTxTestCase = {
   txAuxiliaryData?: string
   expectedResult: SignedTransactionData
   appVersion?: AppVersionOverride
+  requiresExpertMode?: boolean
 }
 
 export const testsByron: SignTxTestCase[] = [
@@ -677,7 +678,8 @@ export const testsShelleyWithCertificates: SignTxTestCase[] = [
   },
   {
     testName: 'Sign_tx_unrestricted_with_pool_retirement_combined_with_stake_registration',
-    appVersion: {unsupportedInAppXS: true},
+    appVersion: {unsupportedInAppXS: true, supportedSinceV8: true},
+    requiresExpertMode: true,
     tx: {
       ...shelleyBase,
       inputs: [

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -4,6 +4,7 @@ import {ImportMock} from 'ts-mock-imports'
 import type {FixLenHexString} from 'types/internal'
 
 import {Ada, utils} from '../src/Ada'
+import {isV7App} from '../src/validation/deviceCapabilities'
 import {DeviceVersionUnsupported, InvalidDataReason} from '../src/errors/index'
 import type {SendParams} from '../src/interactions/common/types'
 import * as parseModule from '../src/utils/parse'
@@ -160,6 +161,7 @@ type SignTxPositiveCase = {
   txBody?: string
   expectedResult: SignedTransactionData
   appVersion?: AppVersionOverride
+  requiresExpertMode?: boolean
 }
 
 function assertSignTxRejectCase(
@@ -309,6 +311,7 @@ export function describeSignTxPositiveTest(
         txBody,
         expectedResult,
         appVersion,
+        requiresExpertMode,
       } = testCase
       it(`${testName} [${signingMode}]`, async () => {
         if (!txBody) {
@@ -316,18 +319,35 @@ export function describeSignTxPositiveTest(
         } else if (hashTxBody(txBody) !== expectedResult.txHashHex) {
           expect.fail(`Tx body hash mismatch for fixture: ${testName}`)
         }
-        const isAppXS = (await ada.getVersion()).version.flags.isAppXS
-        const response = ada.signTransaction({
-          tx,
-          signingMode,
-          additionalWitnessPaths,
-          options,
-        })
+        const {version} = await ada.getVersion()
+        const isAppXS = version.flags.isAppXS
 
-        if (isAppXS && (appVersion?.unsupportedInAppXS ?? false)) {
+        if (isV7App(version) && (appVersion?.supportedSinceV8 ?? false)) {
+          const response = ada.signTransaction({tx, signingMode})
           await expect(response).to.be.rejectedWith(DeviceVersionUnsupported)
-        } else {
-          expect(await response).to.deep.equal(expectedResult)
+          return
+        }
+
+        if (requiresExpertMode) {
+          await ada.debugSetSettings({expertMode: true})
+        }
+        try {
+          const response = ada.signTransaction({
+            tx,
+            signingMode,
+            additionalWitnessPaths,
+            options,
+          })
+
+          if (isAppXS && (appVersion?.unsupportedInAppXS ?? false)) {
+            await expect(response).to.be.rejectedWith(DeviceVersionUnsupported)
+          } else {
+            expect(await response).to.deep.equal(expectedResult)
+          }
+        } finally {
+          if (requiresExpertMode) {
+            await ada.debugSetSettings({expertMode: false}).catch(() => {})
+          }
         }
       })
     }

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -6,14 +6,18 @@ import type {FixLenHexString} from 'types/internal'
 import {Ada, utils} from '../src/Ada'
 import {isV7App} from '../src/validation/deviceCapabilities'
 import {DeviceVersionUnsupported, InvalidDataReason} from '../src/errors/index'
+import {interact} from '../src/interactions/common/interact'
 import type {SendParams} from '../src/interactions/common/types'
+import {getVersionString} from '../src/utils'
 import * as parseModule from '../src/utils/parse'
+import {debugSetSettings, type DebugSettings} from './debugSetSettings'
 import type {
   BIP32Path,
   SignedTransactionData,
   Transaction,
   TransactionOptions,
   TransactionSigningMode,
+  Version,
 } from '../src/types/public'
 
 export function yieldValue(
@@ -45,6 +49,18 @@ export async function getAda() {
   const transport = await getTransport()
 
   return new Ada(transport)
+}
+
+function setDebugSettings(ada: Ada, version: Version, settings: DebugSettings) {
+  if (isV7App(version)) {
+    throw new DeviceVersionUnsupported(
+      `Debug settings APDU is not supported by Ledger app version ${getVersionString(
+        version,
+      )}.`,
+    )
+  }
+
+  return interact(debugSetSettings(settings), ada._send)
 }
 
 export function turnOffValidation() {
@@ -329,7 +345,7 @@ export function describeSignTxPositiveTest(
         }
 
         if (requiresExpertMode) {
-          await ada.debugSetSettings({expertMode: true})
+          await setDebugSettings(ada, version, {expertMode: true})
         }
         try {
           const response = ada.signTransaction({
@@ -346,7 +362,9 @@ export function describeSignTxPositiveTest(
           }
         } finally {
           if (requiresExpertMode) {
-            await ada.debugSetSettings({expertMode: false}).catch(() => {})
+            await setDebugSettings(ada, version, {expertMode: false}).catch(
+              () => undefined,
+            )
           }
         }
       })


### PR DESCRIPTION
Added unrestricted transaction fixture.
Added debug settings interaction (including expert mode).
Expert mode enabled before sending unrestricted mode transaction to sign and disabled afterwards.
Assumed V7 app is not supporting unrestricted mode.

